### PR TITLE
fix: Remove default for VRRP interface group

### DIFF
--- a/routeros/resource_interface_vrrp.go
+++ b/routeros/resource_interface_vrrp.go
@@ -56,7 +56,7 @@ func ResourceInterfaceVrrp() *schema.Resource {
 		"group_master": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Default:     "none",
+			Computed:    true,
 			Description: "Allows combining multiple VRRP interfaces to maintain the same VRRP status within the group.",
 			// Maybe this is a bug, but for the 'none' value, the Mikrotik ROS 7.5 returns an empty string.
 			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {


### PR DESCRIPTION
Using RouterOS 7.7 we are facing errors related to the group used by multiple VRRP interface:

```
Error: from RouterOS device: input does not match any value of group-master
with routeros_interface_vrrp.interface_vrrp["4"],
on vrrp.tf line 3, in resource "routeros_interface_vrrp" "interface_vrrp":
  3: resource "routeros_interface_vrrp" "interface_vrrp" {
```

when declaring a VRRP interface:

```
resource "routeros_interface_vrrp" "interface_vrrp" {
  for_each  = { for interface in local.interfaces : interface.interface_id => interface }
  interface = "ether${each.value.interface_id}"
  name      = "vrrp${each.value.interface_id}"
  comment   = "${each.value.comment}_gw"
  priority  = "200"
  vrid      = "42"
}
```

This change remove the default value to avoid providing a group name on the interface to the API.

The request to the API was:

```
request body: /interface/vrrp/add =group-master= =comment=TEST_STAGING_gw =interval=1s =arp-timeout=auto =disabled=no =priority=200 =arp=enabled =vrid=42 =preemption-mode=yes =authentication=none =name=vrrp13 =version=3 =interface=ether13 =sync-connection-tracking=no =v3-protocol=ipv4
```

The request to the API is now:

```
request body: /interface/vrrp/add =comment=TEST_STAGING_gw =interval=1s =arp-timeout=auto =disabled=no =priority=200 =arp=enabled =vrid=42 =preemption-mode=yes =authentication=none =name=vrrp13 =version=3 =interface=ether13 =sync-connection-tracking=no =v3-protocol=ipv4
```