### PR TITLE
fix: Fix the creation of resources when renaming them

### DIFF
--- a/examples/resources/routeros_ip_pool/resource.tf
+++ b/examples/resources/routeros_ip_pool/resource.tf
@@ -1,4 +1,4 @@
 resource "routeros_ip_pool" "pool" {
   name   = "my_ip_pool"
-  ranges = "10.0.0.100-10.0.0.200"
+  ranges = ["10.0.0.100-10.0.0.200"]
 }

--- a/examples/resources/routeros_system_scheduler/resource.tf
+++ b/examples/resources/routeros_system_scheduler/resource.tf
@@ -1,4 +1,4 @@
 resource "routeros_system_scheduler" "schedule1" {
   name     = "schedule1"
-  on-event = "script name"
+  on_event = "script name"
 }

--- a/routeros/provider_schema_helpers.go
+++ b/routeros/provider_schema_helpers.go
@@ -150,6 +150,11 @@ var (
 	PropNameRw = &schema.Schema{
 		Type:     schema.TypeString,
 		Required: true,
+		ForceNew: true,
+		Description: `Changing the name of this resource will force it to be recreated.
+	> The links of other configuration properties to this resource may be lost!
+	> Changing the name of the resource outside of a Terraform will result in a loss of control integrity for that resource!
+`,
 	}
 	PropPlaceBefore = &schema.Schema{
 		Type:     schema.TypeString,

--- a/routeros/resource_system_identity.go
+++ b/routeros/resource_system_identity.go
@@ -11,7 +11,10 @@ func ResourceSystemIdentity() *schema.Resource {
 		MetaResourcePath: PropResourcePath("/system/identity"),
 		MetaId:           PropId(Name),
 
-		KeyName: PropNameRw,
+		KeyName: {
+			Type:     schema.TypeString,
+			Required: true,
+		},
 	}
 
 	return &schema.Resource{


### PR DESCRIPTION
Preserving the integrity of resource management with the key field "name" when renaming them
Fixes #192