### PR TITLE
Remove extra space after passthrough in validation

### DIFF
--- a/routeros/resource_ip_firewall_mangle.go
+++ b/routeros/resource_ip_firewall_mangle.go
@@ -35,7 +35,7 @@ func ResourceIPFirewallMangle() *schema.Resource {
 			ValidateFunc: validation.StringInSlice([]string{
 				"accept", "add-dst-to-address-list", "add-src-to-address-list", "change-dscp", "change-mss",
 				"change-ttl", "clear-df", "fasttrack-connection", "jump", "log", "mark-connection", "mark-packet",
-				"mark-routing", "passthrough ", "return", "route", "set-priority", "sniff-pc", "sniff-tzsp",
+				"mark-routing", "passthrough", "return", "route", "set-priority", "sniff-pc", "sniff-tzsp",
 				"strip-ipv4-options",
 			}, false),
 		},


### PR DESCRIPTION
Fix after getting this error message:

```
Error: expected action to be one of [accept add-dst-to-address-list add-src-to-address-list change-dscp change-mss change-ttl clear-df fasttrack-connection jump log mark-connection mark-packet mark-routing passthrough  return route set-priority sniff-pc sniff-tzsp strip-ipv4-options], got passthrough
```
