### PR TITLE
Document allowed url schemes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ terraform {
 }
 
 provider "routeros" {
-  hosturl        = "https://router.local"        # env ROS_HOSTURL or MIKROTIK_HOST
+  hosturl        = "apis://router.local"         # env ROS_HOSTURL or MIKROTIK_HOST
   username       = "admin"                       # env ROS_USERNAME or MIKROTIK_USER
   password       = ""                            # env ROS_PASSWORD or MIKROTIK_PASSWORD
   ca_certificate = "/path/to/ca/certificate.pem" # env ROS_CA_CERTIFICATE or MIKROTIK_CA_CERTIFICATE
@@ -43,7 +43,9 @@ resource "routeros_interface_gre" "gre_hq" {
 
 ### Required
 
-- `hosturl` (String) URL of the ROS router. Include the scheme (http/https)
+- `hosturl` (String) URL of the ROS router including the scheme:
+  - `api` http access on port 8728
+  - `apis` https access on port 8729
 
 ### Optional
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ terraform {
 }
 
 provider "routeros" {
-  hosturl        = "apis://router.local"         # env ROS_HOSTURL or MIKROTIK_HOST
+  hosturl        = "https://router.local"        # env ROS_HOSTURL or MIKROTIK_HOST
   username       = "admin"                       # env ROS_USERNAME or MIKROTIK_USER
   password       = ""                            # env ROS_PASSWORD or MIKROTIK_PASSWORD
   ca_certificate = "/path/to/ca/certificate.pem" # env ROS_CA_CERTIFICATE or MIKROTIK_CA_CERTIFICATE
@@ -43,9 +43,7 @@ resource "routeros_interface_gre" "gre_hq" {
 
 ### Required
 
-- `hosturl` (String) URL of the ROS router including the scheme:
-  - `api` http access on port 8728
-  - `apis` https access on port 8729
+- `hosturl` (String) URL of the ROS router. Include the scheme (http/https)
 
 ### Optional
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -21,7 +21,10 @@ To get started with the provider, you first need to enable the REST API on your 
 
 ### Required
 
-- `hosturl` (String) URL of the ROS router. Include the scheme (http/https)
+- `hosturl` (String) URL of the ROS router. Include including the scheme:
+  - `https` new REST API with TLS/SSL
+  - `api` old API without TLS/SSL on port 8728
+  - `apis` old API with TLS/SSL 8729
 
 ### Optional
 


### PR DESCRIPTION
Small change to the provider docs to list out the allowable url schemes.

This caught me up for a moment since `http` isn't actually allowed. I documented only the `api` and `apis` schemes, leaving `https` undocumented.

`https`, while allowed, is confusing in its own way since without a port specified 443 would be assumed by most, not 8729. 