### PR TITLE
Create test helper function to test resource exists

### DIFF
--- a/routeros/resource_bgp_connection_test.go
+++ b/routeros/resource_bgp_connection_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testBGPConnectionAddress = "routeros_routing_bgp_connection.test"
@@ -24,28 +22,13 @@ func TestAccBGPConnectionTest_basic(t *testing.T) {
 					{
 						Config: testAccBGPConnectionConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckBGPConnectionExists(testBGPConnectionAddress),
+							testResourcePrimaryInstanceId(testBGPConnectionAddress),
 							resource.TestCheckResourceAttr(testBGPConnectionAddress, "name", "neighbor-test"),
 						),
 					},
 				},
 			})
 		})
-	}
-}
-
-func testAccCheckBGPConnectionExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_bgp_template_test.go
+++ b/routeros/resource_bgp_template_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testBGPTemplateAddress = "routeros_routing_bgp_template.test"
@@ -24,28 +22,13 @@ func TestAccBGPTemplateTest_basic(t *testing.T) {
 					{
 						Config: testAccBGPTemplateConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckBGPTemplateExists(testBGPTemplateAddress),
+							testResourcePrimaryInstanceId(testBGPTemplateAddress),
 							resource.TestCheckResourceAttr(testBGPTemplateAddress, "name", "test-template"),
 						),
 					},
 				},
 			})
 		})
-	}
-}
-
-func testAccCheckBGPTemplateExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_capsman_channel_test.go
+++ b/routeros/resource_capsman_channel_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testCapsManChannelAddress = "routeros_capsman_channel.test_channel"
@@ -24,28 +22,13 @@ func TestAccCapsManChannelTest_basic(t *testing.T) {
 					{
 						Config: testAccCapsManChannelConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckCapsManChannelExists(testCapsManChannelAddress),
+							testResourcePrimaryInstanceId(testCapsManChannelAddress),
 							resource.TestCheckResourceAttr(testCapsManChannelAddress, "name", "test_channel"),
 						),
 					},
 				},
 			})
 		})
-	}
-}
-
-func testAccCheckCapsManChannelExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_capsman_configuration_test.go
+++ b/routeros/resource_capsman_configuration_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testCapsManConfigurationAddress = "routeros_capsman_configuration.test_configuration"
@@ -24,7 +22,7 @@ func TestAccCapsManConfigurationTest_basic(t *testing.T) {
 					{
 						Config: testAccCapsManConfigurationConfig(0),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckCapsManConfigurationExists(testCapsManConfigurationAddress),
+							testResourcePrimaryInstanceId(testCapsManConfigurationAddress),
 							resource.TestCheckResourceAttr(testCapsManConfigurationAddress, "name", "test_configuration"),
 						),
 					},
@@ -47,21 +45,6 @@ func TestAccCapsManConfigurationTest_basic(t *testing.T) {
 				},
 			})
 		})
-	}
-}
-
-func testAccCheckCapsManConfigurationExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_capsman_datapath_test.go
+++ b/routeros/resource_capsman_datapath_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testCapsManDatapathAddress = "routeros_capsman_datapath.test_datapath"
@@ -24,28 +22,13 @@ func TestAccCapsManDatapathTest_basic(t *testing.T) {
 					{
 						Config: testAccCapsManDatapathConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckCapsManDatapathExists(testCapsManDatapathAddress),
+							testResourcePrimaryInstanceId(testCapsManDatapathAddress),
 							resource.TestCheckResourceAttr(testCapsManDatapathAddress, "name", "test_datapath"),
 						),
 					},
 				},
 			})
 		})
-	}
-}
-
-func testAccCheckCapsManDatapathExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_capsman_manager_test.go
+++ b/routeros/resource_capsman_manager_test.go
@@ -24,7 +24,7 @@ func TestAccCapsManManagerTest_basic(t *testing.T) {
 					{
 						Config: testAccCapsManManagerUnitConfig(name, "routeros_capsman_manager"),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckCapsManResourceExists(testCapsManManagerAddress),
+							testResourcePrimaryInstanceId(testCapsManManagerAddress),
 							resource.TestCheckResourceAttr(testCapsManManagerAddress, "id", "caps-man.manager"),
 						),
 					},

--- a/routeros/resource_capsman_manager_test.go
+++ b/routeros/resource_capsman_manager_test.go
@@ -1,12 +1,10 @@
 package routeros
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testCapsManAaaAddress = "routeros_capsman_aaa.test_3a"
@@ -33,35 +31,20 @@ func TestAccCapsManManagerTest_basic(t *testing.T) {
 					{
 						Config: testAccCapsManManagerUnitConfig(name, "routeros_capsman_aaa"),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckCapsManResourceExists(testCapsManAaaAddress),
+							testResourcePrimaryInstanceId(testCapsManAaaAddress),
 							resource.TestCheckResourceAttr(testCapsManAaaAddress, "id", "caps-man.aaa"),
 						),
 					},
 					{
 						Config: testAccCapsManManagerUnitConfig(name, "routeros_capsman_manager_interface"),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckCapsManResourceExists(testCapsManManagerInterfaceAddress),
+							testResourcePrimaryInstanceId(testCapsManManagerInterfaceAddress),
 							resource.TestCheckResourceAttr(testCapsManManagerInterfaceAddress, "interface", "ether1"),
 						),
 					},
 				},
 			})
 		})
-	}
-}
-
-func testAccCheckCapsManResourceExists(address string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[address]
-		if !ok {
-			return fmt.Errorf("not found: %s", address)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_capsman_provisioning_test.go
+++ b/routeros/resource_capsman_provisioning_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testCapsManProvisioningAddress = "routeros_capsman_provisioning.test_provisioning"
@@ -24,7 +22,7 @@ func TestAccCapsManProvisioningTest_basic(t *testing.T) {
 					{
 						Config: testAccCapsManProvisioningConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckCapsManProvisioningExists(testCapsManProvisioningAddress),
+							testResourcePrimaryInstanceId(testCapsManProvisioningAddress),
 							resource.TestCheckResourceAttr(testCapsManProvisioningAddress, "name_prefix", "cap-"),
 						),
 					},
@@ -32,21 +30,6 @@ func TestAccCapsManProvisioningTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckCapsManProvisioningExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_capsman_rates_test.go
+++ b/routeros/resource_capsman_rates_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testCapsManRatesAddress = "routeros_capsman_rates.test_rates"
@@ -24,7 +22,7 @@ func TestAccCapsManRatesTest_basic(t *testing.T) {
 					{
 						Config: testAccCapsManRatesConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckCapsManRatesExists(testCapsManRatesAddress),
+							testResourcePrimaryInstanceId(testCapsManRatesAddress),
 							resource.TestCheckResourceAttr(testCapsManRatesAddress, "name", "test_rates"),
 						),
 					},
@@ -32,21 +30,6 @@ func TestAccCapsManRatesTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckCapsManRatesExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_capsman_security_test.go
+++ b/routeros/resource_capsman_security_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testCapsManSecurityAddress = "routeros_capsman_security.test_security"
@@ -24,7 +22,7 @@ func TestAccCapsManSecurityTest_basic(t *testing.T) {
 					{
 						Config: testAccCapsManSecurityConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckCapsManSecurityExists(testCapsManSecurityAddress),
+							testResourcePrimaryInstanceId(testCapsManSecurityAddress),
 							resource.TestCheckResourceAttr(testCapsManSecurityAddress, "name", "test_security"),
 						),
 					},
@@ -32,21 +30,6 @@ func TestAccCapsManSecurityTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckCapsManSecurityExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_interface_bonding_test.go
+++ b/routeros/resource_interface_bonding_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testInterfaceBondingAddress = "routeros_interface_bonding.test"
@@ -24,28 +22,13 @@ func TestAccInterfaceBondingTest_basic(t *testing.T) {
 					{
 						Config: testAccInterfaceBondingConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckInterfaceBondingExists(testInterfaceBondingAddress),
+							testResourcePrimaryInstanceId(testInterfaceBondingAddress),
 							resource.TestCheckResourceAttr(testInterfaceBondingAddress, "name", "bonding-test"),
 						),
 					},
 				},
 			})
 		})
-	}
-}
-
-func testAccCheckInterfaceBondingExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_interface_bridge_port_test.go
+++ b/routeros/resource_interface_bridge_port_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testInterfaceBridgePortAddress = "routeros_interface_bridge_port.test_port"
@@ -24,7 +22,7 @@ func TestAccInterfaceBridgePortTest_basic(t *testing.T) {
 					{
 						Config: testAccInterfaceBridgePortConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckInterfaceBridgePortExists(testInterfaceBridgePortAddress),
+							testResourcePrimaryInstanceId(testInterfaceBridgePortAddress),
 							resource.TestCheckResourceAttr(testInterfaceBridgePortAddress, "bridge", "bridge"),
 						),
 					},
@@ -32,21 +30,6 @@ func TestAccInterfaceBridgePortTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckInterfaceBridgePortExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_interface_bridge_settings_test.go
+++ b/routeros/resource_interface_bridge_settings_test.go
@@ -1,12 +1,10 @@
 package routeros
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testInterfaceBridgeSettingsAddress = "routeros_interface_bridge_settings.test"
@@ -24,28 +22,13 @@ func TestAccInterfaceBridgeSettingsTest_basic(t *testing.T) {
 					{
 						Config: testAccInterfaceBridgeSettingsConfig(name),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckInterfaceBridgeSettingsExists(testInterfaceBridgeSettingsAddress),
+							testResourcePrimaryInstanceId(testInterfaceBridgeSettingsAddress),
 							resource.TestCheckResourceAttr(testInterfaceBridgeSettingsAddress, "id", "interface.bridge.settings"),
 						),
 					},
 				},
 			})
 		})
-	}
-}
-
-func testAccCheckInterfaceBridgeSettingsExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_interface_bridge_test.go
+++ b/routeros/resource_interface_bridge_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testInterfaceBridgeAddress = "routeros_interface_bridge.test_bridge"
@@ -25,14 +23,14 @@ func TestAccInterfaceBridgeTest_basic(t *testing.T) {
 					{
 						Config: testAccInterfaceBridgeConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckInterfaceBridgeExists(testInterfaceBridgeAddress),
+							testResourcePrimaryInstanceId(testInterfaceBridgeAddress),
 							resource.TestCheckResourceAttr(testInterfaceBridgeAddress, "name", "test_bridge"),
 						),
 					},
 					{
 						Config: testAccInterfaceBridgeConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckInterfaceBridgeExists(testInterfaceBridgeAddressWithSpace),
+							testResourcePrimaryInstanceId(testInterfaceBridgeAddressWithSpace),
 							resource.TestCheckResourceAttr(testInterfaceBridgeAddressWithSpace, "name", "Main bridge"),
 						),
 					},
@@ -40,21 +38,6 @@ func TestAccInterfaceBridgeTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckInterfaceBridgeExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_interface_bridge_vlan_test.go
+++ b/routeros/resource_interface_bridge_vlan_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testInterfaceBridgeVlanAddress = "routeros_interface_bridge_vlan.test_vlan"
@@ -24,7 +22,7 @@ func TestAccInterfaceBridgeVlanTest_basic(t *testing.T) {
 					{
 						Config: testAccInterfaceBridgeVlanConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckInterfaceBridgeVlanExists(testInterfaceBridgeVlanAddress),
+							testResourcePrimaryInstanceId(testInterfaceBridgeVlanAddress),
 							resource.TestCheckResourceAttr(testInterfaceBridgeVlanAddress, "bridge", "bridge"),
 						),
 					},
@@ -34,21 +32,6 @@ func TestAccInterfaceBridgeVlanTest_basic(t *testing.T) {
 		})
 	}
 
-}
-
-func testAccCheckInterfaceBridgeVlanExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
-	}
 }
 
 func testAccInterfaceBridgeVlanConfig() string {

--- a/routeros/resource_interface_ethernet_test.go
+++ b/routeros/resource_interface_ethernet_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testInterfaceEthernetAddress = "routeros_interface_ethernet.test"
@@ -23,7 +21,7 @@ func TestAccInterfaceEthernetTest_basic(t *testing.T) {
 					{
 						Config: testAccInterfaceEthernetConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckInterfaceEthernetExists(testInterfaceEthernetAddress),
+							testResourcePrimaryInstanceId(testInterfaceEthernetAddress),
 							resource.TestCheckResourceAttr(testInterfaceEthernetAddress, "name", "terraform"),
 							resource.TestCheckResourceAttr(testInterfaceEthernetAddress, "mtu", "9000"),
 							resource.TestCheckResourceAttr(testInterfaceEthernetAddress, "advertise", "10000M-full"),
@@ -44,21 +42,6 @@ func TestAccInterfaceEthernetTest_basic(t *testing.T) {
 				},
 			})
 		})
-	}
-}
-
-func testAccCheckInterfaceEthernetExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_interface_gre_test.go
+++ b/routeros/resource_interface_gre_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testGreAddress = "routeros_interface_gre.gre900"
@@ -25,7 +23,7 @@ func TestAccInterfaceGreTest_basic(t *testing.T) {
 					{
 						Config: testAccInterfaceGreConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckInterfaceGreExists(testGreAddress),
+							testResourcePrimaryInstanceId(testGreAddress),
 							resource.TestCheckResourceAttr(testGreAddress, "name", testGreName),
 						),
 					},
@@ -35,21 +33,6 @@ func TestAccInterfaceGreTest_basic(t *testing.T) {
 		})
 	}
 
-}
-
-func testAccCheckInterfaceGreExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
-	}
 }
 
 func testAccInterfaceGreConfig() string {

--- a/routeros/resource_interface_list_member_test.go
+++ b/routeros/resource_interface_list_member_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testInterfaceListMemberAddress = "routeros_interface_list_member.test_list_member"
@@ -24,7 +22,7 @@ func TestAccInterfaceListMemberTest_basic(t *testing.T) {
 					{
 						Config: testAccInterfaceListMemberConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckInterfaceListMemberExists(testInterfaceListMemberAddress),
+							testResourcePrimaryInstanceId(testInterfaceListMemberAddress),
 							resource.TestCheckResourceAttr(testInterfaceListMemberAddress, "interface", "ether1"),
 						),
 					},
@@ -32,21 +30,6 @@ func TestAccInterfaceListMemberTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckInterfaceListMemberExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_interface_list_test.go
+++ b/routeros/resource_interface_list_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testInterfaceListAddress = "routeros_interface_list.test_list"
@@ -24,7 +22,7 @@ func TestAccInterfaceListTest_basic(t *testing.T) {
 					{
 						Config: testAccInterfaceListConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckInterfaceListExists(testInterfaceListAddress),
+							testResourcePrimaryInstanceId(testInterfaceListAddress),
 							resource.TestCheckResourceAttr(testInterfaceListAddress, "name", "test_list"),
 						),
 					},
@@ -32,21 +30,6 @@ func TestAccInterfaceListTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckInterfaceListExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_interface_pppoe_client_test.go
+++ b/routeros/resource_interface_pppoe_client_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testInterfacePPPoEClientAddress = "routeros_interface_pppoe_client.test"
@@ -24,28 +22,13 @@ func TestAccInterfacePPPoEClientTest_basic(t *testing.T) {
 					{
 						Config: testAccInterfacePPPoEClientConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckInterfacePPPoEClientExists(testInterfacePPPoEClientAddress),
+							testResourcePrimaryInstanceId(testInterfacePPPoEClientAddress),
 							resource.TestCheckResourceAttr(testInterfacePPPoEClientAddress, "name", "PPPoE-Out"),
 						),
 					},
 				},
 			})
 		})
-	}
-}
-
-func testAccCheckInterfacePPPoEClientExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_interface_veth_test.go
+++ b/routeros/resource_interface_veth_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testInterfaceVethAddress = "routeros_interface_veth.test"
@@ -24,28 +22,13 @@ func TestAccInterfaceVethTest_basic(t *testing.T) {
 					{
 						Config: testAccInterfaceVethConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckInterfaceVethExists(testInterfaceVethAddress),
+							testResourcePrimaryInstanceId(testInterfaceVethAddress),
 							resource.TestCheckResourceAttr(testInterfaceVethAddress, "name", "veth-test"),
 						),
 					},
 				},
 			})
 		})
-	}
-}
-
-func testAccCheckInterfaceVethExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_interface_vlan_test.go
+++ b/routeros/resource_interface_vlan_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testVlanAddress = "routeros_interface_vlan.vlan900"
@@ -25,7 +23,7 @@ func TestAccInterfaceVlanTest(t *testing.T) {
 					{
 						Config: testAccInterfaceVlanConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckInterfaceVlanExists(testVlanAddress),
+							testResourcePrimaryInstanceId(testVlanAddress),
 							resource.TestCheckResourceAttr(testVlanAddress, "name", testVlanName),
 						),
 					},
@@ -33,21 +31,6 @@ func TestAccInterfaceVlanTest(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckInterfaceVlanExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_interface_vrrp_test.go
+++ b/routeros/resource_interface_vrrp_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testInterfaceVrrpAddress = "routeros_interface_vrrp.test_vrrp_interface"
@@ -24,7 +22,7 @@ func TestAccInterfaceVrrpTest_basic(t *testing.T) {
 					{
 						Config: testAccInterfaceVrrpConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckInterfaceVrrpExists(testInterfaceVrrpAddress),
+							testResourcePrimaryInstanceId(testInterfaceVrrpAddress),
 							resource.TestCheckResourceAttr(testInterfaceVrrpAddress, "interface", "ether1"),
 						),
 					},
@@ -32,21 +30,6 @@ func TestAccInterfaceVrrpTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckInterfaceVrrpExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_interface_wireguard_peer_test.go
+++ b/routeros/resource_interface_wireguard_peer_test.go
@@ -1,13 +1,11 @@
 package routeros
 
 import (
-	"fmt"
 	"reflect"
 	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testInterfaceWireguardPeerAddress = "routeros_interface_wireguard_peer.wg_peer"
@@ -26,7 +24,7 @@ func TestAccInterfaceWireguardPeerTest_basic(t *testing.T) {
 					{
 						Config: testAccInterfaceWireguardPeerConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckInterfaceWireguardPeerExists(testInterfaceWireguardPeerAddress),
+							testResourcePrimaryInstanceId(testInterfaceWireguardPeerAddress),
 							resource.TestCheckResourceAttr(testInterfaceWireguardPeerAddress, "interface", "wg1"),
 						),
 					},
@@ -34,21 +32,6 @@ func TestAccInterfaceWireguardPeerTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckInterfaceWireguardPeerExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_interface_wireguard_test.go
+++ b/routeros/resource_interface_wireguard_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testInterfaceWireguardAddress = "routeros_interface_wireguard.test_wg_interface"
@@ -24,7 +22,7 @@ func TestAccInterfaceWireguardTest_basic(t *testing.T) {
 					{
 						Config: testAccInterfaceWireguardConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckInterfaceWireguardExists(testInterfaceWireguardAddress),
+							testResourcePrimaryInstanceId(testInterfaceWireguardAddress),
 							resource.TestCheckResourceAttr(testInterfaceWireguardAddress, "listen_port", "13231"),
 						),
 					},
@@ -32,21 +30,6 @@ func TestAccInterfaceWireguardTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckInterfaceWireguardExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ip_address_test.go
+++ b/routeros/resource_ip_address_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testInterfaceIPAddressAddress = "routeros_ip_address.test_ip_address"
@@ -24,7 +22,7 @@ func TestAccInterfaceIPAddressTest_basic(t *testing.T) {
 					{
 						Config: testAccInterfaceIPAddressConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckInterfaceIPAddressExists(testInterfaceIPAddressAddress),
+							testResourcePrimaryInstanceId(testInterfaceIPAddressAddress),
 							resource.TestCheckResourceAttr(testInterfaceIPAddressAddress, "address", "172.16.255.254/32"),
 						),
 					},
@@ -32,21 +30,6 @@ func TestAccInterfaceIPAddressTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckInterfaceIPAddressExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ip_cloud_test.go
+++ b/routeros/resource_ip_cloud_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testIpCloudAddress = "routeros_ip_cloud.test"
@@ -23,49 +21,34 @@ func TestAccIpCloudTest_basic(t *testing.T) {
 					{
 						Config: testAccIpCloudConfig(0),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckIpCloudExists(testIpCloudAddress),
+							testResourcePrimaryInstanceId(testIpCloudAddress),
 							resource.TestCheckResourceAttr(testIpCloudAddress, "ddns_update_interval", "none"),
 						),
 					},
 					{
 						Config: testAccIpCloudConfig(1),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckIpCloudExists(testIpCloudAddress),
+							testResourcePrimaryInstanceId(testIpCloudAddress),
 							resource.TestCheckResourceAttr(testIpCloudAddress, "ddns_update_interval", "15m"),
 						),
 					},
 					{
 						Config: testAccIpCloudConfig(2),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckIpCloudExists(testIpCloudAddress),
+							testResourcePrimaryInstanceId(testIpCloudAddress),
 							resource.TestCheckResourceAttr(testIpCloudAddress, "ddns_update_interval", "10m"),
 						),
 					},
 					{
 						Config: testAccIpCloudConfig(3),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckIpCloudExists(testIpCloudAddress),
+							testResourcePrimaryInstanceId(testIpCloudAddress),
 							resource.TestCheckResourceAttr(testIpCloudAddress, "ddns_update_interval", "none"),
 						),
 					},
 				},
 			})
 		})
-	}
-}
-
-func testAccCheckIpCloudExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ip_dhcp_client_test.go
+++ b/routeros/resource_ip_dhcp_client_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testIpDhcpClientAddress = "routeros_ip_dhcp_client.test_dhcp"
@@ -24,7 +22,7 @@ func TestAccIpDhcpClientTest_basic(t *testing.T) {
 					{
 						Config: testAccIpDhcpClientConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckIpDhcpClientExists(testIpDhcpClientAddress),
+							testResourcePrimaryInstanceId(testIpDhcpClientAddress),
 							resource.TestCheckResourceAttr(testIpDhcpClientAddress, "interface", "bridge"),
 						),
 					},
@@ -32,21 +30,6 @@ func TestAccIpDhcpClientTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckIpDhcpClientExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ip_dhcp_server_lease_test.go
+++ b/routeros/resource_ip_dhcp_server_lease_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testIpDhcpServerLease = "routeros_ip_dhcp_server_lease.test_dhcp_lease"
@@ -24,7 +22,7 @@ func TestAccIpDhcpServerLeaseTest_basic(t *testing.T) {
 					{
 						Config: testAccIpDhcpServerLeaseConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckIpDhcpServerLeaseExists(testIpDhcpServerLease),
+							testResourcePrimaryInstanceId(testIpDhcpServerLease),
 							resource.TestCheckResourceAttr(testIpDhcpServerLease, "address", "192.168.88.33"),
 							resource.TestCheckResourceAttr(testIpDhcpServerLease, "mac_address", "AA:BB:CC:DD:EE:FF"),
 							resource.TestCheckResourceAttr(testIpDhcpServerLease, "block_access", "true"),
@@ -34,21 +32,6 @@ func TestAccIpDhcpServerLeaseTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckIpDhcpServerLeaseExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ip_dhcp_server_network_test.go
+++ b/routeros/resource_ip_dhcp_server_network_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testIpDhcpServerNetworkAddress = "routeros_ip_dhcp_server_network.test_dhcp"
@@ -24,7 +22,7 @@ func TestAccIpDhcpServerNetworkTest_basic(t *testing.T) {
 					{
 						Config: testAccIpDhcpServerNetworkConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckIpDhcpServerNetworkExists(testIpDhcpServerNetworkAddress),
+							testResourcePrimaryInstanceId(testIpDhcpServerNetworkAddress),
 							resource.TestCheckResourceAttr(testIpDhcpServerNetworkAddress, "address", "192.168.1.0/24"),
 						),
 					},
@@ -32,21 +30,6 @@ func TestAccIpDhcpServerNetworkTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckIpDhcpServerNetworkExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ip_dhcp_server_option_sets_test.go
+++ b/routeros/resource_ip_dhcp_server_option_sets_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testIpDhcpServerOptionSet = "routeros_ip_dhcp_server_option_set.test_option_set"
@@ -24,7 +22,7 @@ func TestAccIpDhcpServerNetworkOptionSet_basic(t *testing.T) {
 					{
 						Config: testAccIpDhcpServerOptionSetConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckIpDhcpServerOptionSetExists(testIpDhcpServerOptionSet),
+							testResourcePrimaryInstanceId(testIpDhcpServerOptionSet),
 							resource.TestCheckResourceAttr(testIpDhcpServerOptionSet, "name", "test-opt-set"),
 							resource.TestCheckResourceAttr(testIpDhcpServerOptionSet, "options", "test-opt1,test-opt2"),
 						),
@@ -33,21 +31,6 @@ func TestAccIpDhcpServerNetworkOptionSet_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckIpDhcpServerOptionSetExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ip_dhcp_server_option_test.go
+++ b/routeros/resource_ip_dhcp_server_option_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testIpDhcpServerOption = "routeros_ip_dhcp_server_option.test_option"
@@ -24,7 +22,7 @@ func TestAccIpDhcpServerNetworkOption_basic(t *testing.T) {
 					{
 						Config: testAccIpDhcpServerOptionConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckIpDhcpServerOptionExists(testIpDhcpServerOption),
+							testResourcePrimaryInstanceId(testIpDhcpServerOption),
 							resource.TestCheckResourceAttr(testIpDhcpServerOption, "code", "77"),
 							resource.TestCheckResourceAttr(testIpDhcpServerOption, "name", "test-opt"),
 							resource.TestCheckResourceAttr(testIpDhcpServerOption, "value", "s'10.10.10.22'"),
@@ -36,21 +34,6 @@ func TestAccIpDhcpServerNetworkOption_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckIpDhcpServerOptionExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ip_dhcp_server_test.go
+++ b/routeros/resource_ip_dhcp_server_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testIpDhcpServerAddress = "routeros_ip_dhcp_server.test_dhcp"
@@ -24,7 +22,7 @@ func TestAccIpDhcpServerTest_basic(t *testing.T) {
 					{
 						Config: testAccIpDhcpServerConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckIpDhcpServerExists(testIpDhcpServerAddress),
+							testResourcePrimaryInstanceId(testIpDhcpServerAddress),
 							resource.TestCheckResourceAttr(testIpDhcpServerAddress, "interface", "bridge"),
 						),
 					},
@@ -32,21 +30,6 @@ func TestAccIpDhcpServerTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckIpDhcpServerExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ip_dns_record_test.go
+++ b/routeros/resource_ip_dns_record_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccIpDnsRecordTest_basic(t *testing.T) {
@@ -23,47 +21,47 @@ func TestAccIpDnsRecordTest_basic(t *testing.T) {
 						Config: testAccIpDnsRecordConfig(),
 						Check: resource.ComposeTestCheckFunc(
 							// A
-							testAccCheckIpDnsRecordExists("routeros_dns_record.test_dns_a"),
+							testResourcePrimaryInstanceId("routeros_dns_record.test_dns_a"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_a", "name", "ipv4"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_a", "address", "127.0.0.1"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_a", "type", "A"),
 							// A regexp
-							testAccCheckIpDnsRecordExists("routeros_dns_record.test_dns_a_regexp"),
+							testResourcePrimaryInstanceId("routeros_dns_record.test_dns_a_regexp"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_a", "address", "127.0.0.1"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_a_regexp", "regexp", "regexp"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_a_regexp", "type", "A"),
 							// AAAA
-							testAccCheckIpDnsRecordExists("routeros_dns_record.test_dns_aaaa"),
+							testResourcePrimaryInstanceId("routeros_dns_record.test_dns_aaaa"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_aaaa", "name", "ipv6"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_aaaa", "address", "ff00::1"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_aaaa", "type", "AAAA"),
 							// CNAME
-							testAccCheckIpDnsRecordExists("routeros_dns_record.test_dns_cname"),
+							testResourcePrimaryInstanceId("routeros_dns_record.test_dns_cname"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_cname", "cname", "ipv4"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_cname", "name", "cname"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_cname", "type", "CNAME"),
 							// FWD
-							testAccCheckIpDnsRecordExists("routeros_dns_record.test_dns_fwd"),
+							testResourcePrimaryInstanceId("routeros_dns_record.test_dns_fwd"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_fwd", "name", "fwd"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_fwd", "forward_to", "127.0.0.1"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_fwd", "type", "FWD"),
 							// MX
-							testAccCheckIpDnsRecordExists("routeros_dns_record.test_dns_mx"),
+							testResourcePrimaryInstanceId("routeros_dns_record.test_dns_mx"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_mx", "name", "mx"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_mx", "mx_exchange", "127.0.0.1"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_mx", "mx_preference", "10"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_mx", "type", "MX"),
 							// NS
-							testAccCheckIpDnsRecordExists("routeros_dns_record.test_dns_ns"),
+							testResourcePrimaryInstanceId("routeros_dns_record.test_dns_ns"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_ns", "name", "ns"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_ns", "ns", "127.0.0.1"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_ns", "type", "NS"),
 							// NXDOMAIN
-							testAccCheckIpDnsRecordExists("routeros_dns_record.test_dns_nxdomain"),
+							testResourcePrimaryInstanceId("routeros_dns_record.test_dns_nxdomain"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_nxdomain", "name", "nxdomain"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_nxdomain", "type", "NXDOMAIN"),
 							// SRV
-							testAccCheckIpDnsRecordExists("routeros_dns_record.test_dns_srv"),
+							testResourcePrimaryInstanceId("routeros_dns_record.test_dns_srv"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_srv", "name", "srv"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_srv", "srv_port", "8080"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_srv", "srv_priority", "10"),
@@ -71,7 +69,7 @@ func TestAccIpDnsRecordTest_basic(t *testing.T) {
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_srv", "srv_weight", "100"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_srv", "type", "SRV"),
 							// TXT
-							testAccCheckIpDnsRecordExists("routeros_dns_record.test_dns_txt"),
+							testResourcePrimaryInstanceId("routeros_dns_record.test_dns_txt"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_txt", "name", "_acme-challenge.yourwebsite.com"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_txt", "text", "dW6MrI3nBy3eJgYWH3QAg1Cwk_TvjFESOuKo+mp6nm1"),
 							resource.TestCheckResourceAttr("routeros_dns_record.test_dns_txt", "type", "TXT"),
@@ -81,21 +79,6 @@ func TestAccIpDnsRecordTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckIpDnsRecordExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ip_dns_test.go
+++ b/routeros/resource_ip_dns_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testResourceDnsTask = "routeros_dns.test"
@@ -23,7 +21,7 @@ func TestAccResourceDnsTest_basic(t *testing.T) {
 					{
 						Config: testAccResourceDnsConfig(0),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckResourceDnsExists(testResourceDnsTask),
+							testResourcePrimaryInstanceId(testResourceDnsTask),
 							resource.TestCheckResourceAttr(testResourceDnsTask, "allow_remote_requests", "true"),
 						),
 					},
@@ -34,21 +32,6 @@ func TestAccResourceDnsTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckResourceDnsExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ip_firewall_addr_list_test.go
+++ b/routeros/resource_ip_firewall_addr_list_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testIPFirewallrAddrList = "routeros_firewall_addr_list.data"
@@ -24,7 +22,7 @@ func TestAccIPFirewallAddrListTest_basic(t *testing.T) {
 					{
 						Config: testAccIPFirewallAddrListConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckIPFirewallAddrListExists(testIPFirewallrAddrList),
+							testResourcePrimaryInstanceId(testIPFirewallrAddrList),
 							resource.TestCheckResourceAttr(testIPFirewallrAddrList, "list", "test-addr-list"),
 							resource.TestCheckResourceAttr(testIPFirewallrAddrList, "address", "192.168.0.0/23"),
 						),
@@ -33,21 +31,6 @@ func TestAccIPFirewallAddrListTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckIPFirewallAddrListExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ip_firewall_filter_test.go
+++ b/routeros/resource_ip_firewall_filter_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testIPFirewallFilterAddress = "routeros_firewall_filter.rule"
@@ -24,7 +22,7 @@ func TestAccIPFirewallFilterTest_basic(t *testing.T) {
 					{
 						Config: testAccIPFirewallFilterConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckIPFirewallFilterExists(testIPFirewallFilterAddress),
+							testResourcePrimaryInstanceId(testIPFirewallFilterAddress),
 							resource.TestCheckResourceAttr(testIPFirewallFilterAddress, "action", "accept"),
 						),
 					},
@@ -32,21 +30,6 @@ func TestAccIPFirewallFilterTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckIPFirewallFilterExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ip_firewall_mangle_test.go
+++ b/routeros/resource_ip_firewall_mangle_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testIPFirewallMangle = "routeros_firewall_mangle.data"
@@ -24,7 +22,7 @@ func TestAccIPFirewallMangleTest_basic(t *testing.T) {
 					{
 						Config: testAccIPFirewallMangleConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckIPFirewallMangleExists(testIPFirewallMangle),
+							testResourcePrimaryInstanceId(testIPFirewallMangle),
 							resource.TestCheckResourceAttr(testIPFirewallMangle, "chain", "prerouting"),
 							resource.TestCheckResourceAttr(testIPFirewallMangle, "action", "mark-connection"),
 							resource.TestCheckResourceAttr(testIPFirewallMangle, "new_connection_mark", "test-mark"),
@@ -34,21 +32,6 @@ func TestAccIPFirewallMangleTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckIPFirewallMangleExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ip_firewall_nat_test.go
+++ b/routeros/resource_ip_firewall_nat_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testIPFirewallNat = "routeros_firewall_nat.data"
@@ -24,7 +22,7 @@ func TestAccIPFirewallNatTest_basic(t *testing.T) {
 					{
 						Config: testAccIPFirewallNatConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckIPFirewallNatExists(testIPFirewallNat),
+							testResourcePrimaryInstanceId(testIPFirewallNat),
 							resource.TestCheckResourceAttr(testIPFirewallNat, "chain", "srcnat"),
 							resource.TestCheckResourceAttr(testIPFirewallNat, "action", "masquerade"),
 							resource.TestCheckResourceAttr(testIPFirewallNat, "disabled", "true"),
@@ -34,21 +32,6 @@ func TestAccIPFirewallNatTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckIPFirewallNatExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ip_pool_test.go
+++ b/routeros/resource_ip_pool_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testIpPoolAddress = "routeros_ip_pool.test_pool"
@@ -24,7 +22,7 @@ func TestAccIpPoolTest_basic(t *testing.T) {
 					{
 						Config: testAccIpPoolConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckIpPoolExists(testIpPoolAddress),
+							testResourcePrimaryInstanceId(testIpPoolAddress),
 							resource.TestCheckResourceAttr(testIpPoolAddress, "name", "test_pool"),
 						),
 					},
@@ -32,21 +30,6 @@ func TestAccIpPoolTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckIpPoolExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ip_route_test.go
+++ b/routeros/resource_ip_route_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testIpRouteAddress = "routeros_ip_route.test_route"
@@ -24,7 +22,7 @@ func TestAccIpRouteTest_basic(t *testing.T) {
 					{
 						Config: testAccIpRouteConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckIpRouteExists(testIpRouteAddress),
+							testResourcePrimaryInstanceId(testIpRouteAddress),
 							resource.TestCheckResourceAttr(testIpRouteAddress, "distance", "1"),
 							resource.TestCheckResourceAttr(testIpRouteAddress, "dst_address", "10.0.0.0/24"),
 							resource.TestCheckResourceAttr(testIpRouteAddress, "gateway", "192.168.103.1"),
@@ -34,21 +32,6 @@ func TestAccIpRouteTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckIpRouteExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ip_service_test.go
+++ b/routeros/resource_ip_service_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testIpServiceAddress = "routeros_ip_service.telnet"
@@ -23,28 +21,13 @@ func TestAccIpServiceTest_basic(t *testing.T) {
 					{
 						Config: testAccIpServiceConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckIpServiceExists(testIpServiceAddress),
+							testResourcePrimaryInstanceId(testIpServiceAddress),
 							resource.TestCheckResourceAttr(testIpServiceAddress, "name", "telnet"),
 						),
 					},
 				},
 			})
 		})
-	}
-}
-
-func testAccCheckIpServiceExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ipv6_address_test.go
+++ b/routeros/resource_ipv6_address_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testInterfaceIPv6AddressAddress = "routeros_ipv6_address.test_v6_address"
@@ -24,7 +23,7 @@ func TestAccInterfaceIPv6AddressTest_basic(t *testing.T) {
 					{
 						Config: testAccInterfaceIPv6AddressConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckInterfaceIPv6AddressExists(testInterfaceIPv6AddressAddress),
+							testResourcePrimaryInstanceId(testInterfaceIPv6AddressAddress),
 							resource.TestCheckResourceAttrWith(testInterfaceIPv6AddressAddress, "address",
 								func(value string) error {
 									if value[:7] != "fc00:3:" {
@@ -38,21 +37,6 @@ func TestAccInterfaceIPv6AddressTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckInterfaceIPv6AddressExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ipv6_firewall_addr_list_test.go
+++ b/routeros/resource_ipv6_firewall_addr_list_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testIPv6FirewallAddrList = "routeros_ipv6_firewall_addr_list.data"
@@ -24,7 +22,7 @@ func TestAccIPv6FirewallAddrListTest_basic(t *testing.T) {
 					{
 						Config: testAccIPv6FirewallAddrListConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckIPv6FirewallAddrListExists(testIPv6FirewallAddrList),
+							testResourcePrimaryInstanceId(testIPv6FirewallAddrList),
 							resource.TestCheckResourceAttr(testIPv6FirewallAddrList, "list", "test-addr-list"),
 							resource.TestCheckResourceAttr(testIPv6FirewallAddrList, "address", "123:dead:beaf::/64"),
 						),
@@ -33,21 +31,6 @@ func TestAccIPv6FirewallAddrListTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckIPv6FirewallAddrListExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ipv6_firewall_filter_test.go
+++ b/routeros/resource_ipv6_firewall_filter_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testIPv6FirewallFilterAddress = "routeros_ipv6_firewall_filter.rule"
@@ -24,7 +22,7 @@ func TestAccIPv6FirewallFilterTest_basic(t *testing.T) {
 					{
 						Config: testAccIPv6FirewallFilterConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckIPv6FirewallFilterExists(testIPv6FirewallFilterAddress),
+							testResourcePrimaryInstanceId(testIPv6FirewallFilterAddress),
 							resource.TestCheckResourceAttr(testIPv6FirewallFilterAddress, "action", "drop"),
 						),
 					},
@@ -32,21 +30,6 @@ func TestAccIPv6FirewallFilterTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckIPv6FirewallFilterExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ipv6_route_test.go
+++ b/routeros/resource_ipv6_route_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testIPv6RouteAddress = "routeros_ipv6_route.test_route"
@@ -24,7 +22,7 @@ func TestAccIPv6RouteTest_basic(t *testing.T) {
 					{
 						Config: testAccIPv6RouteConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckIPv6RouteExists(testIPv6RouteAddress),
+							testResourcePrimaryInstanceId(testIPv6RouteAddress),
 							resource.TestCheckResourceAttr(testIPv6RouteAddress, "distance", "1"),
 							resource.TestCheckResourceAttr(testIPv6RouteAddress, "dst_address", "::/0"),
 							resource.TestCheckResourceAttr(testIPv6RouteAddress, "gateway", "2001:db8:1000::1"),
@@ -34,21 +32,6 @@ func TestAccIPv6RouteTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckIPv6RouteExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ovpn_server_test.go
+++ b/routeros/resource_ovpn_server_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testOpenVPNServerMinVersion = "7.8"
@@ -30,8 +28,8 @@ func TestAccOpenVPNServerTest_basic(t *testing.T) {
 					{
 						Config: testAccOpenVPNServerConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckOpenVPNServerExists(testOpenVPNServer),
-							testAccCheckOpenVPNServerExists(testInterfaceOpenVPNServer),
+							testResourcePrimaryInstanceId(testOpenVPNServer),
+							testResourcePrimaryInstanceId(testInterfaceOpenVPNServer),
 							resource.TestCheckResourceAttr(testOpenVPNServer, "id", "interface.ovpn-server.server"),
 							resource.TestCheckResourceAttr(testInterfaceOpenVPNServer, "name", "ovpn-in1"),
 							resource.TestCheckResourceAttr(testInterfaceOpenVPNServer, "user", "user1"),
@@ -41,21 +39,6 @@ func TestAccOpenVPNServerTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckOpenVPNServerExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ppp_profile_test.go
+++ b/routeros/resource_ppp_profile_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testPPPProfile = "routeros_ppp_profile.test"
@@ -24,7 +22,7 @@ func TestAccPPPProfileTest_basic(t *testing.T) {
 					{
 						Config: testAccPPPProfileConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckPPPProfileExists(testPPPProfile),
+							testResourcePrimaryInstanceId(testPPPProfile),
 							resource.TestCheckResourceAttr(testPPPProfile, "name", "profile1"),
 						),
 					},
@@ -32,21 +30,6 @@ func TestAccPPPProfileTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckPPPProfileExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_ppp_secret_test.go
+++ b/routeros/resource_ppp_secret_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testPPPSecret = "routeros_ppp_secret.test"
@@ -24,7 +22,7 @@ func TestAccPPPSecretTest_basic(t *testing.T) {
 					{
 						Config: testAccPPPSecretConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckPPPSecretExists(testPPPSecret),
+							testResourcePrimaryInstanceId(testPPPSecret),
 							resource.TestCheckResourceAttr(testPPPSecret, "name", "user-test"),
 						),
 					},
@@ -32,21 +30,6 @@ func TestAccPPPSecretTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckPPPSecretExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_routing_ospf_area_test.go
+++ b/routeros/resource_routing_ospf_area_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testRoutingOspfArea = "routeros_routing_ospf_area.test_routing_ospf_area"
@@ -24,7 +22,7 @@ func TestAccRoutingOspfInstanceArea_basic(t *testing.T) {
 					{
 						Config: testAccCheckRoutingOspfAreaConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckRoutingOspfAreaExists(testRoutingOspfArea),
+							testResourcePrimaryInstanceId(testRoutingOspfArea),
 							resource.TestCheckResourceAttr(testRoutingOspfArea, "name", "test_routing_ospf_area"),
 						),
 					},
@@ -32,21 +30,6 @@ func TestAccRoutingOspfInstanceArea_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckRoutingOspfAreaExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_routing_ospf_instance_test.go
+++ b/routeros/resource_routing_ospf_instance_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testRoutingOspfInstance = "routeros_routing_ospf_instance.test_routing_ospf_instance"
@@ -24,7 +22,7 @@ func TestAccRoutingOspfInstanceTest_basic(t *testing.T) {
 					{
 						Config: testAccCheckRoutingOspfInstanceConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckRoutingOspfInstanceExists(testRoutingOspfInstance),
+							testResourcePrimaryInstanceId(testRoutingOspfInstance),
 							resource.TestCheckResourceAttr(testRoutingOspfInstance, "name", "test_routing_ospf_instance"),
 						),
 					},
@@ -32,21 +30,6 @@ func TestAccRoutingOspfInstanceTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckRoutingOspfInstanceExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_routing_ospf_interface_template_test.go
+++ b/routeros/resource_routing_ospf_interface_template_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testRoutingOspfInterfaceTemplate = "routeros_routing_ospf_interface_template.test_routing_ospf_interface_template"
@@ -24,7 +22,7 @@ func TestAccRoutingOspfInterfaceTemplateTest_basic(t *testing.T) {
 					{
 						Config: testAccCheckRoutingOspfInterfaceTemplateConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckRoutingOspfInterfaceTemplateExists(testRoutingOspfInterfaceTemplate),
+							testResourcePrimaryInstanceId(testRoutingOspfInterfaceTemplate),
 							resource.TestCheckResourceAttr(testRoutingOspfInterfaceTemplate, "area", "test_routing_ospf_area"),
 						),
 					},
@@ -32,21 +30,6 @@ func TestAccRoutingOspfInterfaceTemplateTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckRoutingOspfInterfaceTemplateExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_routing_table_test.go
+++ b/routeros/resource_routing_table_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testRoutingTableAddress = "routeros_routing_table.test_table"
@@ -24,7 +22,7 @@ func TestAccRoutingTableTest_basic(t *testing.T) {
 					{
 						Config: testAccRoutingTableConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckRoutingTableExists(testRoutingTableAddress),
+							testResourcePrimaryInstanceId(testRoutingTableAddress),
 							resource.TestCheckResourceAttr(testRoutingTableAddress, "name", "to_ISP1"),
 						),
 					},
@@ -32,21 +30,6 @@ func TestAccRoutingTableTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckRoutingTableExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_snmp_community_test.go
+++ b/routeros/resource_snmp_community_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testSNMPCommunityAddress = "routeros_snmp_community.test"
@@ -24,28 +22,13 @@ func TestAccSNMPCommunityTest_basic(t *testing.T) {
 					{
 						Config: testAccSNMPCommunityConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckSNMPCommunityExists(testSNMPCommunityAddress),
+							testResourcePrimaryInstanceId(testSNMPCommunityAddress),
 							resource.TestCheckResourceAttr(testSNMPCommunityAddress, "name", "private"),
 						),
 					},
 				},
 			})
 		})
-	}
-}
-
-func testAccCheckSNMPCommunityExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_system_certificate_test.go
+++ b/routeros/resource_system_certificate_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testSystemCertificatesAddress = "routeros_system_certificate.root_ca"
@@ -24,7 +22,7 @@ func TestAccSystemCertificatesTest_basic(t *testing.T) {
 					{
 						Config: testAccSystemCertificatesConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckSystemCertificatesExists(testSystemCertificatesAddress),
+							testResourcePrimaryInstanceId(testSystemCertificatesAddress),
 							resource.TestCheckResourceAttr(testSystemCertificatesAddress, "name", "Test-Root-CA"),
 						),
 					},
@@ -32,21 +30,6 @@ func TestAccSystemCertificatesTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckSystemCertificatesExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_system_identity_test.go
+++ b/routeros/resource_system_identity_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testSystemIdentityTask = "routeros_identity.test"
@@ -23,7 +22,7 @@ func TestAccSystemIdentityTest_basic(t *testing.T) {
 					{
 						Config: testAccSystemIdentityConfig("TestRouter_" + name),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckSystemIdentityExists(testSystemIdentityTask),
+							testResourcePrimaryInstanceId(testSystemIdentityTask),
 							resource.TestCheckResourceAttr(testSystemIdentityTask, "name", "TestRouter_"+name),
 						),
 					},
@@ -37,21 +36,6 @@ func TestAccSystemIdentityTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckSystemIdentityExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_system_logging_test.go
+++ b/routeros/resource_system_logging_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testSystemSimpleLoggingTask = "routeros_system_logging.simple_logging"
@@ -23,7 +21,7 @@ func TestAccSystemLoggingTest_basic(t *testing.T) {
 					{
 						Config: testAccSystemLoggingConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckLoggingExists(testSystemSimpleLoggingTask),
+							testResourcePrimaryInstanceId(testSystemSimpleLoggingTask),
 							resource.TestCheckResourceAttr(testSystemSimpleLoggingTask, "action", "echo"),
 							resource.TestCheckResourceAttr(testSystemSimpleLoggingTask, "disabled", "false"),
 							resource.TestCheckResourceAttr(testSystemSimpleLoggingTask, "invalid", "false"),
@@ -36,21 +34,6 @@ func TestAccSystemLoggingTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckLoggingExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_system_scheduler_test.go
+++ b/routeros/resource_system_scheduler_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testSystemSchedulerTask = "routeros_scheduler.test_task"
@@ -24,7 +22,7 @@ func TestAccSystemSchedulerTest_basic(t *testing.T) {
 					{
 						Config: testAccSystemSchedulerConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckSystemSchedulerExists(testSystemSchedulerTask),
+							testResourcePrimaryInstanceId(testSystemSchedulerTask),
 							resource.TestCheckResourceAttr(testSystemSchedulerTask, "disabled", "true"),
 							resource.TestCheckResourceAttr(testSystemSchedulerTask, "name", "TestTask"),
 							resource.TestCheckResourceAttr(testSystemSchedulerTask, "on_event", "script1"),
@@ -34,21 +32,6 @@ func TestAccSystemSchedulerTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckSystemSchedulerExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_system_user_test.go
+++ b/routeros/resource_system_user_test.go
@@ -1,11 +1,9 @@
 package routeros
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const testUserAddress = "routeros_system_user.test"
@@ -25,7 +23,7 @@ func TestAccUserTest_basic(t *testing.T) {
 					{
 						Config: testAccUserConfig(),
 						Check: resource.ComposeTestCheckFunc(
-							testAccCheckUserExists(testUserAddress),
+							testResourcePrimaryInstanceId(testUserAddress),
 							resource.TestCheckResourceAttr(testUserAddress, "name", "test-user-1"),
 						),
 					},
@@ -33,21 +31,6 @@ func TestAccUserTest_basic(t *testing.T) {
 			})
 
 		})
-	}
-}
-
-func testAccCheckUserExists(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("not found: %s", name)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no id is set")
-		}
-
-		return nil
 	}
 }
 

--- a/routeros/resource_testing_helper.go
+++ b/routeros/resource_testing_helper.go
@@ -1,0 +1,22 @@
+package routeros
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func testResourcePrimaryInstanceId(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no id is set")
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
All tests included an resource specific function to test wether the resource exists in it's primary state and had ID assigned.

This PR extracts the function in a generic way and refactor it's usages across the tests.
