### PR TITLE
fix: Fix double slash at the end of a hostname

### DIFF
--- a/routeros/mikrotik_client.go
+++ b/routeros/mikrotik_client.go
@@ -76,6 +76,7 @@ func NewClient(ctx context.Context, d *schema.ResourceData) (interface{}, diag.D
 			},
 		}
 	}
+	routerUrl.Path = strings.TrimSuffix(routerUrl.Path, "/")
 
 	var useTLS = true
 	var transport = TransportREST


### PR DESCRIPTION
Fixes #275