### PR TITLE
fix: Fix empty value check to handle default numeric values correctly

### DIFF
--- a/docs/resources/interface_eoip.md
+++ b/docs/resources/interface_eoip.md
@@ -43,7 +43,7 @@ resource "routeros_interface_eoip" "eoip_tunnel1" {
 - `loop_protect_send_interval` (String)
 - `mtu` (String) Layer3 Maximum transmission unit ('auto', 0 .. 65535)
 - `remote_address` (String) IP address of the remote end of the tunnel.
-- `tunnel_id` (String) Unique tunnel identifier, which must match the other side of the tunnel.
+- `tunnel_id` (Number) Unique tunnel identifier, which must match the other side of the tunnel.
 
 ### Read-Only
 

--- a/routeros/mikrotik_serialize.go
+++ b/routeros/mikrotik_serialize.go
@@ -48,7 +48,7 @@ func isEmpty(propName string, schemaProp *schema.Schema, d *schema.ResourceData,
 		}
 		return v.(string) == "" && confValue.IsNull()
 	case schema.TypeInt:
-		return !d.HasChange(propName)
+		return confValue.IsNull() && schemaProp.Default == nil
 	case schema.TypeBool:
 		// If true, it is always not empty:
 		if v.(bool) {

--- a/routeros/resource_interface_eoip.go
+++ b/routeros/resource_interface_eoip.go
@@ -34,9 +34,9 @@ func ResourceInterfaceEoip() *schema.Resource {
 		KeyRemoteAddress:           PropRemoteAddressRw,
 		KeyRunning:                 PropRunningRo,
 		"tunnel_id": {
-			Type:        schema.TypeString,
+			Type:        schema.TypeInt,
 			Optional:    true,
-			Default:     "0",
+			Default:     0,
 			Description: "Unique tunnel identifier, which must match the other side of the tunnel.",
 		},
 	}


### PR DESCRIPTION
While working on #283, I discovered that optional numeric fields with `0` as a default value are skipped even though they appear in the planned changes. That also takes place when we use `0` in the configuration, and the related field either has no default value or has `0` in there:

```go
"tunnel_id": {
	Type:        schema.TypeInt,
	Optional:    true,
	Default:     0,
	Description: "Unique tunnel identifier, which must match the other side of the tunnel.",
},
```

```terraform
resource "routeros_interface_eoip" "eoip2" {
  name           = "eoip2"
}
```

```
Terraform will perform the following actions:

  # routeros_interface_eoip.eoip2 will be created
  + resource "routeros_interface_eoip" "eoip2" {
      + actual_mtu                 = (known after apply)
      + allow_fast_path            = true
      + arp                        = "enabled"
      + arp_timeout                = "auto"
      + clamp_tcp_mss              = true
      + disabled                   = false
      + dont_fragment              = "no"
      + dscp                       = "inherit"
      + id                         = (known after apply)
      + keepalive                  = "10s,10"
      + l2mtu                      = (known after apply)
      + local_address              = "0.0.0.0"
      + loop_protect               = "default"
      + loop_protect_disable_time  = "5m"
      + loop_protect_send_interval = "5s"
      + loop_protect_status        = (known after apply)
      + mac_address                = (known after apply)
      + mtu                        = (known after apply)
      + name                       = "eoip2"
      + remote_address             = "0.0.0.0"
      + running                    = (known after apply)
      + tunnel_id                  = 0
    }

Plan: 1 to add, 0 to change, 0 to destroy.

...

Error: from RouterOS device: missing =tunnel-id=
│ 
│   with routeros_interface_eoip.eoip2,
│   on main.tf line 236, in resource "routeros_interface_eoip" "eoip2":
```

The problem in the provider's code is that `HasChange` returns `false` when the default is `0`:
https://github.com/terraform-routeros/terraform-provider-routeros/blob/678c9a4c67d2553e3bc72dc6a29d14d415520fa6/routeros/mikrotik_serialize.go#L51

After drilling down into the origin of this problem, I found out that terraform SDK casts `null` to `0`, and therefore, `HasChange` [compares](https://github.com/hashicorp/terraform-plugin-sdk/blob/6b58e7f3b33cdd12471c31846c8862a00b8db28b/helper/schema/resource_data.go#L165) two zeros.

https://github.com/hashicorp/terraform-plugin-sdk/issues/817#issuecomment-1098708632 explained the nature of such behavior and convinced me that it doesn't make much sense to try to fix that on the SDK side. So, I slightly changed the empty check logic not to skip such values.

Unfortunately, I could not cover that with a unit test in [`mikrotik_serialize_test.go`](https://github.com/terraform-routeros/terraform-provider-routeros/blob/main/routeros/mikrotik_serialize_test.go) because it uses the `GetRawConfig` method, which always returns a null value when using either [`TestResourceData`](https://github.com/hashicorp/terraform-plugin-sdk/blob/v2.29.0/helper/schema/resource.go#L1358) or [`TestResourceDataRaw`](https://github.com/hashicorp/terraform-plugin-sdk/blob/v2.29.0/helper/schema/testing.go#L15). And I couldn't find a clean way to set the raw config in the resource data state.