### PR TITLE
feat: Add DHCP server config resource

### DIFF
--- a/examples/resources/routeros_ip_dhcp_server_config/import.sh
+++ b/examples/resources/routeros_ip_dhcp_server_config/import.sh
@@ -1,0 +1,1 @@
+terraform import routeros_ip_dhcp_server_config.settings .

--- a/examples/resources/routeros_ip_dhcp_server_config/resource.tf
+++ b/examples/resources/routeros_ip_dhcp_server_config/resource.tf
@@ -1,0 +1,6 @@
+resource "routeros_ip_dhcp_server_config" "settings" {
+  accounting = true
+  interim_update = "1m"
+  radius_password = "same-as-user"
+  store_leases_disk = "10m"
+}

--- a/routeros/provider.go
+++ b/routeros/provider.go
@@ -66,6 +66,7 @@ func Provider() *schema.Provider {
 			// IP objects
 			"routeros_ip_dhcp_client":                  ResourceDhcpClient(),
 			"routeros_ip_dhcp_server":                  ResourceDhcpServer(),
+			"routeros_ip_dhcp_server_config":           ResourceDhcpServerConfig(),
 			"routeros_ip_dhcp_server_network":          ResourceDhcpServerNetwork(),
 			"routeros_ip_dhcp_server_lease":            ResourceDhcpServerLease(),
 			"routeros_ip_dhcp_server_option":           ResourceDhcpServerOption(),

--- a/routeros/resource_ip_dhcp_server_config.go
+++ b/routeros/resource_ip_dhcp_server_config.go
@@ -1,0 +1,53 @@
+package routeros
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+// ResourceDhcpServerConfig https://help.mikrotik.com/docs/display/ROS/DHCP#DHCP-StoreConfiguration
+func ResourceDhcpServerConfig() *schema.Resource {
+	resSchema := map[string]*schema.Schema{
+		MetaResourcePath: PropResourcePath("/ip/dhcp-server/config"),
+		MetaId:           PropId(Id),
+
+		"accounting": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "An option that enables accounting for DHCP leases.",
+		},
+		"interim_update": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "0s",
+			Description: "An option determining whether the DHCP server sends periodic updates to the accounting server during a lease.",
+			DiffSuppressFunc: TimeEquall,
+		},
+		"radius_password": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "empty",
+			Description: "An option to set the password parameter for the RADIUS server. This option is available in RouterOS starting from version 7.0.",
+			ValidateFunc: validation.StringInSlice([]string{"empty", "same-as-user"}, false),
+		},
+		"store_leases_disk": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "5m",
+			Description: "An option of how often the DHCP leases will be stored on disk.",
+			DiffSuppressFunc: TimeEquall,
+		},
+	}
+	return &schema.Resource{
+		CreateContext: DefaultSystemCreate(resSchema),
+		ReadContext:   DefaultSystemRead(resSchema),
+		UpdateContext: DefaultSystemUpdate(resSchema),
+		DeleteContext: DefaultSystemDelete(resSchema),
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: resSchema,
+	}
+}


### PR DESCRIPTION
This PR adds missing DHCP-server config resource. The schema diverges in only one property -- `radius-password` was added in 7.0.