### PR TITLE
Bump Go version from 1.19 to 1.21

### DIFF
--- a/.github/workflows/module_testing.yml
+++ b/.github/workflows/module_testing.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         experimental: [false]
         go:
-          - 1.19
+          - 1.21
         os: [ubuntu-latest]
         routeros_version:
           - "7.7"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.release.outputs.new_release_published == 'true'
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.21
 
       - name: Run GoReleaser
         if: steps.release.outputs.new_release_published == 'true'

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For more in-depth documentation about each of the resources and datasources, ple
 
 ### Versions tested
 
-- go 1.19 and ROS 7.7, 7.8, 7.9 (stable)
+- go 1.21 and ROS 7.7, 7.8, 7.9 (stable)
 
 ## Changelog
 


### PR DESCRIPTION
Error: ../../../go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.30.0/terraform/state.go:321:16: undefined: errors.Join
note: module requires Go 1.20