### PR TITLE
fix: Skip computed stat fields

### DIFF
--- a/routeros/resource_interface_bridge_port.go
+++ b/routeros/resource_interface_bridge_port.go
@@ -71,6 +71,7 @@ func ResourceInterfaceBridgePort() *schema.Resource {
 	resSchema := map[string]*schema.Schema{
 		MetaResourcePath: PropResourcePath("/interface/bridge/port"),
 		MetaId:           PropId(Id),
+		MetaSkipFields:   PropSkipFields(`"debug_info","port_number"`),
 
 		"nextid": {
 			Type:     schema.TypeString,
@@ -103,10 +104,6 @@ func ResourceInterfaceBridgePort() *schema.Resource {
 				"When disabled, drops broadcast traffic on egress ports. ",
 		},
 		KeyComment: PropCommentRw,
-		"debug_info": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
 		"designated_bridge": {
 			Type:        schema.TypeString,
 			Computed:    true,
@@ -254,12 +251,6 @@ func ResourceInterfaceBridgePort() *schema.Resource {
 			Type:        schema.TypeBool,
 			Computed:    true,
 			Description: "Whether the port is connected to a bridge port using full-duplex (true) or half-duplex (false).",
-		},
-		"port_number": {
-			Type:     schema.TypeInt,
-			Computed: true,
-			Description: "Port number will be assigned in the order that ports got added to the bridge, " +
-				"but this is only true until reboot. After reboot internal numbering will be used.",
 		},
 		"priority": {
 			Type:     schema.TypeString,

--- a/routeros/resource_interface_ethernet.go
+++ b/routeros/resource_interface_ethernet.go
@@ -54,7 +54,16 @@ func ResourceInterfaceEthernet() *schema.Resource {
 	resSchema := map[string]*schema.Schema{
 		MetaResourcePath: PropResourcePath("/interface/ethernet"),
 		MetaId:           PropId(Id),
-		MetaSkipFields:   PropSkipFields(`"factory_name"`),
+		MetaSkipFields:   PropSkipFields(`"factory_name","driver_rx_byte","driver_rx_packet","driver_tx_byte","driver_tx_packet",` +
+			`"rx_64","rx_65_127","rx_128_255","rx_256_511","rx_512_1023","rx_1024_1518","rx_1519_max",` +
+			`"tx_64","tx_65_127","tx_128_255","tx_256_511","tx_512_1023","tx_1024_1518","tx_1519_max",` +
+			`"tx_rx_64","tx_rx_65_127","tx_rx_128_255","tx_rx_256_511","tx_rx_512_1023","tx_rx_1024_1518","tx_rx_1519_max",` +
+			`"rx_broadcast","rx_bytes","rx_control","rx_drop","rx_fcs_error","rx_fragment","rx_jabber","rx_multicast","rx_packet","rx_pause","rx_too_short","rx_too_long",` +
+			`"tx_broadcast","tx_bytes","tx_control","tx_drop","tx_fcs_error","tx_fragment","tx_jabber","tx_multicast","tx_packet","tx_pause","tx_too_short","tx_too_long",` +
+			`"rx_align_error","rx_carrier_error","rx_code_error","rx_length_error","rx_overflow","rx_unknown_op",` +
+			`"tx_collision","tx_excessive_collision","tx_late_collision","tx_multiple_collision","tx_single_collision","tx_total_collision",` +
+			`"tx_deferred","tx_excessive_deferred","tx_underrun",`),
+
 		"advertise": {
 			Type:     schema.TypeString,
 			Optional: true,
@@ -114,26 +123,6 @@ func ResourceInterfaceEthernet() *schema.Resource {
 			Default value is 'yes' because older NICs do not support it. (only applicable to x86)`,
 			Default:  true,
 			Optional: true,
-		},
-		"driver_rx_byte": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: `Total count of received bytes on device CPU`,
-		},
-		"driver_rx_packet": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: `Total count of received packets on device CPU`,
-		},
-		"driver_tx_byte": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: `Total count of transmitted packets by device CPU`,
-		},
-		"driver_tx_packet": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: `Total count of transmitted packets by device CPU`,
 		},
 		"factory_name": {
 			Type:        schema.TypeString,
@@ -201,51 +190,6 @@ func ResourceInterfaceEthernet() *schema.Resource {
 			Description: "Whether interface is running. Note that some interface does not have running check and they are always reported as \"running\"",
 			Computed:    true,
 		},
-		"rx_broadcast": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Total count of received broadcast frames.",
-		},
-		"rx_bytes": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Total count of received bytes.",
-		},
-		"rx_error_events": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: `Total count of received frames with active error event`,
-		},
-		"rx_fcs_error": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Total count of received frames with incorrect checksum",
-		},
-		"rx_fragment": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: `Total count of received fragmented frames (not related to IP fragmentation)`,
-		},
-		"rx_jabber": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Total count of received jabbed packets - a packet that is transmitted longer than the maximum packet length",
-		},
-		"rx_multicast": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Total count of received multicast frames.",
-		},
-		"rx_packet": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Total count of received packets.",
-		},
-		"rx_pause": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Total count of received pause frames",
-		},
 		"rx_flow_control": {
 			Type: schema.TypeString,
 			Description: `When set to on, the port will process received pause frames and suspend transmission if required.
@@ -254,26 +198,6 @@ func ResourceInterfaceEthernet() *schema.Resource {
 			Optional:         true,
 			ValidateFunc:     validation.StringInSlice([]string{"on", "off", "auto"}, false),
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
-		},
-		"rx_overflow": {
-			Type:        schema.TypeInt,
-			Description: `Total count of received overflowed frames, can be caused when device resources are insufficient to receive a certain frame`,
-			Computed:    true,
-		},
-		"rx_too_long": {
-			Type:        schema.TypeInt,
-			Description: `Total count of received frames that were larger than the maximum supported frame size by the network device, see the max-l2mtu property`,
-			Computed:    true,
-		},
-		"rx_too_short": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: `Total count of received frame shorter than the minimum 64 bytes`,
-		},
-		"rx_unicast": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: `Total count of received unicast frames`,
 		},
 		"sfp_rate_select": {
 			Type:         schema.TypeString,
@@ -313,87 +237,6 @@ func ResourceInterfaceEthernet() *schema.Resource {
 			Optional:         true,
 			ValidateFunc:     validation.StringInSlice([]string{"on", "off", "auto"}, false),
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
-		},
-		"tx_broadcast": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Total count of transmitted broadcast frames.",
-		},
-		"tx_bytes": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Total count of transmitted bytes.",
-		},
-		"tx_multicast": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Total count of transmitted multicast frames.",
-		},
-		"tx_collision": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Total count of transmitted frames that made collisions",
-		},
-		"tx_drop": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Total count of transmitted frames that were dropped due to already full output queue",
-		},
-
-		"tx_late_collision": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Total count of transmitted frames that made collision after being already halfway transmitted",
-		},
-		"tx_packet": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Total count of transmitted packets.",
-		},
-		"tx_pause": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Total count of transmitted pause frames.",
-		},
-		"tx_rx_64": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Total count of transmitted and received 64 byte frames",
-		},
-		"tx_rx_65_127": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Total count of transmitted and received 64 to 127 byte frames",
-		},
-		"tx_rx_128_255": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Total count of transmitted and received 128 to 255 byte frames",
-		},
-		"tx_rx_256_511": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Total count of transmitted and received 256 to 511 byte frames",
-		},
-		"tx_rx_512_1023": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Total count of transmitted and received 512 to 1024 byte frames",
-		},
-		"tx_rx_1024_max": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Total count of transmitted and received 1024 or above byte frames",
-		},
-		"tx_underrun": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Total count of transmitted underrun packets",
-		},
-		"tx_unicast": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Total count of transmitted unicast frames.",
 		},
 	}
 

--- a/routeros/resource_ip_firewall_connection_tracking.go
+++ b/routeros/resource_ip_firewall_connection_tracking.go
@@ -35,6 +35,8 @@ func ResourceIPConnectionTracking() *schema.Resource {
 	resSchema := map[string]*schema.Schema{
 		MetaResourcePath: PropResourcePath("/ip/firewall/connection/tracking"),
 		MetaId:           PropId(Name),
+		MetaSkipFields:   PropSkipFields(`"total_entries"`),
+
 		"active_ipv4": {
 			Type:        schema.TypeBool,
 			Computed:    true,
@@ -149,11 +151,6 @@ func ResourceIPConnectionTracking() *schema.Resource {
 			Description:      "No documentation",
 			ValidateFunc:     ValidationTime,
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
-		},
-		"total_entries": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Amount of connections that currently connection table holds.",
 		},
 		"udp_stream_timeout": {
 			Type:             schema.TypeString,

--- a/routeros/resource_ip_firewall_connection_tracking_test.go
+++ b/routeros/resource_ip_firewall_connection_tracking_test.go
@@ -1,9 +1,6 @@
 package routeros
 
 import (
-	"errors"
-	"fmt"
-	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -49,7 +46,6 @@ func TestAccIPConnectionTrackingTest_basic(t *testing.T) {
 							resource.TestCheckResourceAttr(testIPConnectionTracking, "tcp_syn_sent_timeout", "3m"),
 							resource.TestCheckResourceAttr(testIPConnectionTracking, "tcp_time_wait_timeout", "3m"),
 							resource.TestCheckResourceAttr(testIPConnectionTracking, "tcp_unacked_timeout", "3m"),
-							resource.TestCheckResourceAttrWith(testIPConnectionTracking, "total_entries", connectionsIsInAcceptableRange),
 							resource.TestCheckResourceAttr(testIPConnectionTracking, "udp_stream_timeout", "3m"),
 							resource.TestCheckResourceAttr(testIPConnectionTracking, "udp_timeout", "3m"),
 						),
@@ -76,7 +72,6 @@ func TestAccIPConnectionTrackingTest_basic(t *testing.T) {
 							resource.TestCheckResourceAttr(testIPConnectionTracking, "tcp_syn_sent_timeout", "3m"),
 							resource.TestCheckResourceAttr(testIPConnectionTracking, "tcp_time_wait_timeout", "3m"),
 							resource.TestCheckResourceAttr(testIPConnectionTracking, "tcp_unacked_timeout", "3m"),
-							resource.TestCheckResourceAttrWith(testIPConnectionTracking, "total_entries", connectionsIsInAcceptableRange),
 							resource.TestCheckResourceAttr(testIPConnectionTracking, "udp_stream_timeout", "3m"),
 							resource.TestCheckResourceAttr(testIPConnectionTracking, "udp_timeout", "3m"),
 						),
@@ -118,15 +113,4 @@ resource "routeros_ip_firewall_connection_tracking" "data" {
 }
 
 `
-}
-
-func connectionsIsInAcceptableRange(value string) error {
-	nConn, err := strconv.Atoi(value)
-	if err != nil {
-		return fmt.Errorf("the total_entries was not a number %q", err)
-	}
-	if nConn <= 0 || nConn >= 100 {
-		return errors.New("number of tcp connections (total_entries) does not seem correct")
-	}
-	return nil
 }

--- a/routeros/resource_ip_firewall_filter.go
+++ b/routeros/resource_ip_firewall_filter.go
@@ -14,7 +14,7 @@ func ResourceIPFirewallFilter() *schema.Resource {
 	resSchema := map[string]*schema.Schema{
 		MetaResourcePath: PropResourcePath("/ip/firewall/filter"),
 		MetaId:           PropId(Id),
-		MetaSkipFields:   PropSkipFields(``),
+		MetaSkipFields:   PropSkipFields(`"bytes","packets"`),
 
 		"action": {
 			Type:        schema.TypeString,
@@ -38,11 +38,6 @@ func ResourceIPFirewallFilter() *schema.Resource {
 				"address-list parameter. Used in conjunction with add-dst-to-address-list or add-src-to-address-list " +
 				"actions.",
 			DiffSuppressFunc: TimeEquall,
-		},
-		"bytes": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "The total amount of bytes matched by the rule.",
 		},
 		"chain": {
 			Type:     schema.TypeString,
@@ -266,11 +261,6 @@ func ResourceIPFirewallFilter() *schema.Resource {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "Set of interfaces defined in interface list. Works the same as out-interface.",
-		},
-		"packets": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "The total amount of packets matched by the rule.",
 		},
 		"packet_mark": {
 			Type:     schema.TypeString,

--- a/routeros/resource_ip_firewall_mangle.go
+++ b/routeros/resource_ip_firewall_mangle.go
@@ -29,7 +29,7 @@ func ResourceIPFirewallMangle() *schema.Resource {
 	resSchema := map[string]*schema.Schema{
 		MetaResourcePath: PropResourcePath("/ip/firewall/mangle"),
 		MetaId:           PropId(Id),
-		MetaSkipFields:   PropSkipFields(``),
+		MetaSkipFields:   PropSkipFields(`"bytes","packets"`),
 
 		"action": {
 			Type:        schema.TypeString,
@@ -55,11 +55,6 @@ func ResourceIPFirewallMangle() *schema.Resource {
 			Description: "Time interval after which the address will be removed from the address list specified by " +
 				"address-list parameter. Used in conjunction with add-dst-to-address-list or add-src-to-address-list " +
 				"actions.",
-		},
-		"bytes": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "The total amount of bytes matched by the rule.",
 		},
 		"chain": {
 			Type:     schema.TypeString,
@@ -320,11 +315,6 @@ func ResourceIPFirewallMangle() *schema.Resource {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "Set of interfaces defined in interface list. Works the same as out-interface.",
-		},
-		"packets": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "The total amount of packets matched by the rule.",
 		},
 		"packet_mark": {
 			Type:     schema.TypeString,

--- a/routeros/resource_ip_firewall_nat.go
+++ b/routeros/resource_ip_firewall_nat.go
@@ -31,7 +31,7 @@ func ResourceIPFirewallNat() *schema.Resource {
 	resSchema := map[string]*schema.Schema{
 		MetaResourcePath: PropResourcePath("/ip/firewall/nat"),
 		MetaId:           PropId(Id),
-		MetaSkipFields:   PropSkipFields(``),
+		MetaSkipFields:   PropSkipFields(`"bytes","packets"`),
 
 		"action": {
 			Type:        schema.TypeString,
@@ -55,11 +55,6 @@ func ResourceIPFirewallNat() *schema.Resource {
 			Description: "Time interval after which the address will be removed from the address list specified by " +
 				"address-list parameter. Used in conjunction with add-dst-to-address-list or add-src-to-address-list " +
 				"actions.",
-		},
-		"bytes": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "The total amount of bytes matched by the rule.",
 		},
 		"chain": {
 			Type:     schema.TypeString,
@@ -262,11 +257,6 @@ func ResourceIPFirewallNat() *schema.Resource {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "Set of interfaces defined in interface list. Works the same as out-interface.",
-		},
-		"packets": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "The total amount of packets matched by the rule.",
 		},
 		"packet_mark": {
 			Type:     schema.TypeString,

--- a/routeros/resource_ipv6_firewall_filter.go
+++ b/routeros/resource_ipv6_firewall_filter.go
@@ -12,6 +12,7 @@ func ResourceIPv6FirewallFilter() *schema.Resource {
 	resSchema := map[string]*schema.Schema{
 		MetaResourcePath: PropResourcePath("/ipv6/firewall/filter"),
 		MetaId:           PropId(Id),
+		MetaSkipFields:   PropSkipFields(`"bytes","packets"`),
 
 		"action": {
 			Type:        schema.TypeString,
@@ -33,11 +34,6 @@ func ResourceIPv6FirewallFilter() *schema.Resource {
 			Description: "Time interval after which the address will be removed from the address list specified by " +
 				"address-list parameter. Used in conjunction with add-dst-to-address-list or add-src-to-address-list " +
 				"actions.",
-		},
-		"bytes": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "The total amount of bytes matched by the rule.",
 		},
 		"chain": {
 			Type:     schema.TypeString,
@@ -235,11 +231,6 @@ func ResourceIPv6FirewallFilter() *schema.Resource {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "Set of interfaces defined in interface list. Works the same as out-interface.",
-		},
-		"packets": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "The total amount of packets matched by the rule.",
 		},
 		"packet_mark": {
 			Type:     schema.TypeString,

--- a/routeros/resource_system_logging.go
+++ b/routeros/resource_system_logging.go
@@ -38,6 +38,10 @@ func ResourceSystemLogging() *schema.Resource {
 			Description:  "specifies one of the system default actions or user specified action listed in actions menu",
 			ValidateFunc: validation.StringInSlice([]string{"disk", "echo", "memory", "remote"}, false),
 		},
+		"default": {
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
 		"prefix": {
 			Type:        schema.TypeString,
 			Optional:    true,

--- a/routeros/resource_system_user.go
+++ b/routeros/resource_system_user.go
@@ -22,6 +22,7 @@ func ResourceUser() *schema.Resource {
 	resSchema := map[string]*schema.Schema{
 		MetaResourcePath: PropResourcePath("/user"),
 		MetaId:           PropId(Id),
+		MetaSkipFields:   PropSkipFields(`"last_logged_in"`),
 
 		"address": {
 			Type:        schema.TypeString,
@@ -49,11 +50,6 @@ func ResourceUser() *schema.Resource {
 			Description: "User  password. If not specified, it is left blank (hit [Enter] when logging  in). It " +
 				"conforms to standard Unix characteristics of passwords and may  contain letters, digits, " +
 				"'*' and '_' symbols.",
-		},
-		"last_logged_in": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "Read-only field. Last time and date when a user logged in.",
 		},
 	}
 


### PR DESCRIPTION
While working with the provider, I discovered that it changes the Terraform state on every apply, even though there are no changes. That's caused by constantly changing stats fields (e.g., number of transferred bytes or packets). That breaks the whole concept of the Terraform state and produces state changes without actual "infrastructure" change.

Apart from that, some resources returned many warnings related to the missing schema fields.

This PR tries to address those problems in a backward-compatible way by reusing the `MetaSkipFields` property:
1. Skip stats for the ethernet resources, which were causing a lot of noise in the output (resolves #298).
2. Skip stats for the firewall rules.
3. Skip debug fields from the bridge ports.
4. Skip the last login information for the system users.
5. Add the missing computed field to the system logging resource.

As this PR doesn't explicitly add any new schema fields, the changes are compatible with any supported RouterOS version.