### PR TITLE
feat: Add WiFi resources support

### DIFF
--- a/examples/resources/routeros_wifi_aaa/import.sh
+++ b/examples/resources/routeros_wifi_aaa/import.sh
@@ -1,0 +1,3 @@
+#The ID can be found via API or the terminal
+#The command for the terminal is -> :put [/interface/wifi/aaa get [print show-ids]]
+terraform import routeros_wifi_aaa.aaa1 '*1'

--- a/examples/resources/routeros_wifi_aaa/resource.tf
+++ b/examples/resources/routeros_wifi_aaa/resource.tf
@@ -1,0 +1,6 @@
+resource "routeros_wifi_aaa" "aaa1" {
+  called_format   = "S"
+  name            = "aaa1"
+  password_format = ""
+  username_format = "AA:AA:AA:AA:AA:AA"
+}

--- a/examples/resources/routeros_wifi_access_list/import.sh
+++ b/examples/resources/routeros_wifi_access_list/import.sh
@@ -1,0 +1,3 @@
+#The ID can be found via API or the terminal
+#The command for the terminal is -> :put [/interface/wifi/access-list get [print show-ids]]
+terraform import routeros_wifi_access_list.radius '*1'

--- a/examples/resources/routeros_wifi_access_list/resource.tf
+++ b/examples/resources/routeros_wifi_access_list/resource.tf
@@ -1,0 +1,5 @@
+resource "routeros_wifi_access_list" "radius" {
+  action            = "query-radius"
+  comment           = "RADIUS"
+  radius_accounting = true
+}

--- a/examples/resources/routeros_wifi_cap/import.sh
+++ b/examples/resources/routeros_wifi_cap/import.sh
@@ -1,0 +1,1 @@
+terraform import routeros_wifi_cap.settings .

--- a/examples/resources/routeros_wifi_cap/resource.tf
+++ b/examples/resources/routeros_wifi_cap/resource.tf
@@ -1,0 +1,4 @@
+resource "routeros_wifi_cap" "settings" {
+  enabled              = true
+  discovery_interfaces = ["bridge1"]
+}

--- a/examples/resources/routeros_wifi_capsman/import.sh
+++ b/examples/resources/routeros_wifi_capsman/import.sh
@@ -1,0 +1,1 @@
+terraform import routeros_wifi_capsman.settings .

--- a/examples/resources/routeros_wifi_capsman/resource.tf
+++ b/examples/resources/routeros_wifi_capsman/resource.tf
@@ -1,0 +1,5 @@
+resource "routeros_wifi_capsman" "settings" {
+  enabled        = true
+  interfaces     = ["bridge1"]
+  upgrade_policy = "suggest-same-version"
+}

--- a/examples/resources/routeros_wifi_channel/import.sh
+++ b/examples/resources/routeros_wifi_channel/import.sh
@@ -1,0 +1,3 @@
+#The ID can be found via API or the terminal
+#The command for the terminal is -> :put [/interface/wifi/channel get [print show-ids]]
+terraform import routeros_wifi_channel.channel1 '*1'

--- a/examples/resources/routeros_wifi_channel/resource.tf
+++ b/examples/resources/routeros_wifi_channel/resource.tf
@@ -1,0 +1,8 @@
+resource "routeros_wifi_channel" "channel1" {
+  name                  = "1"
+  band                  = "2ghz-n"
+  frequency             = [2412]
+  secondary_frequency   = ["disabled"]
+  skip_dfs_channels     = "disabled"
+  width                 = "20mhz"
+}

--- a/examples/resources/routeros_wifi_configuration/import.sh
+++ b/examples/resources/routeros_wifi_configuration/import.sh
@@ -1,0 +1,3 @@
+#The ID can be found via API or the terminal
+#The command for the terminal is -> :put [/interface/wifi/configuration get [print show-ids]]
+terraform import routeros_wifi_configuration.configuration1 '*1'

--- a/examples/resources/routeros_wifi_configuration/resource.tf
+++ b/examples/resources/routeros_wifi_configuration/resource.tf
@@ -1,0 +1,50 @@
+resource "routeros_wifi_aaa" "aaa1" {
+  called_format   = "S"
+  name            = "aaa1"
+  password_format = ""
+  username_format = "AA:AA:AA:AA:AA:AA"
+}
+
+resource "routeros_wifi_channel" "channel1" {
+  name                  = "1"
+  band                  = "2ghz-n"
+  frequency             = [2412]
+  secondary_frequency   = ["disabled"]
+  skip_dfs_channels     = "disabled"
+  width                 = "20mhz"
+}
+
+resource "routeros_wifi_datapath" "datapath1" {
+  name             = "datapath1"
+  bridge           = "bridge1"
+  client_isolation = false
+}
+
+resource "routeros_wifi_security" "security1" {
+  name                 = "security1"
+  authentication_types = ["wpa2-psk", "wpa3-psk"]
+  ft                   = true
+  ft_preserve_vlanid   = true
+  passphrase           = "password"
+}
+
+resource "routeros_wifi_configuration" "configuration1" {
+  country = "Netherlands"
+  manager = "capsman"
+  mode    = "ap"
+  name    = "configuration1"
+  ssid    = "my-network"
+
+  aaa = {
+    config = routeros_wifi_aaa.aaa1.name
+  }
+  channel = {
+    config = routeros_wifi_channel.channel1.name
+  }
+  datapath = {
+    config = routeros_wifi_datapath.datapath1.name
+  }
+  security = {
+    config = routeros_wifi_security.security1.name
+  }
+}

--- a/examples/resources/routeros_wifi_datapath/import.sh
+++ b/examples/resources/routeros_wifi_datapath/import.sh
@@ -1,0 +1,3 @@
+#The ID can be found via API or the terminal
+#The command for the terminal is -> :put [/interface/wifi/datapath get [print show-ids]]
+terraform import routeros_wifi_datapath.datapath1 '*1'

--- a/examples/resources/routeros_wifi_datapath/resource.tf
+++ b/examples/resources/routeros_wifi_datapath/resource.tf
@@ -1,0 +1,5 @@
+resource "routeros_wifi_datapath" "datapath1" {
+  name             = "datapath1"
+  bridge           = "bridge1"
+  client_isolation = false
+}

--- a/examples/resources/routeros_wifi_interworking/import.sh
+++ b/examples/resources/routeros_wifi_interworking/import.sh
@@ -1,0 +1,3 @@
+#The ID can be found via API or the terminal
+#The command for the terminal is -> :put [/interface/wifi/interworking get [print show-ids]]
+terraform import routeros_wifi_interworking.interworking1 '*1'

--- a/examples/resources/routeros_wifi_interworking/resource.tf
+++ b/examples/resources/routeros_wifi_interworking/resource.tf
@@ -1,0 +1,4 @@
+resource "routeros_wifi_interworking" "interworking1" {
+  name     = "interworking1"
+  internet = true
+}

--- a/examples/resources/routeros_wifi_provisioning/import.sh
+++ b/examples/resources/routeros_wifi_provisioning/import.sh
@@ -1,0 +1,3 @@
+#The ID can be found via API or the terminal
+#The command for the terminal is -> :put [/interface/wifi/provisioning get [print show-ids]]
+terraform import routeros_wifi_provisioning.provisioning1 '*1'

--- a/examples/resources/routeros_wifi_provisioning/resource.tf
+++ b/examples/resources/routeros_wifi_provisioning/resource.tf
@@ -1,0 +1,14 @@
+resource "routeros_wifi_configuration" "configuration1" {
+  country = "Netherlands"
+  manager = "capsman"
+  mode    = "ap"
+  name    = "configuration1"
+  ssid    = "my-network"
+}
+
+resource "routeros_wifi_provisioning" "provisioning1" {
+  action               = "create-enabled"
+  master_configuration = routeros_wifi_configuration.configuration1.name
+  name_format          = "cap1:"
+  radio_mac            = "00:11:22:33:44:55"
+}

--- a/examples/resources/routeros_wifi_security/import.sh
+++ b/examples/resources/routeros_wifi_security/import.sh
@@ -1,0 +1,3 @@
+#The ID can be found via API or the terminal
+#The command for the terminal is -> :put [/interface/wifi/security get [print show-ids]]
+terraform import routeros_wifi_security.security1 '*1'

--- a/examples/resources/routeros_wifi_security/resource.tf
+++ b/examples/resources/routeros_wifi_security/resource.tf
@@ -1,0 +1,7 @@
+resource "routeros_wifi_security" "security1" {
+  name                 = "security1"
+  authentication_types = ["wpa2-psk", "wpa3-psk"]
+  ft                   = true
+  ft_preserve_vlanid   = true
+  passphrase           = "password"
+}

--- a/examples/resources/routeros_wifi_steering/import.sh
+++ b/examples/resources/routeros_wifi_steering/import.sh
@@ -1,0 +1,3 @@
+#The ID can be found via API or the terminal
+#The command for the terminal is -> :put [/interface/wifi/steering get [print show-ids]]
+terraform import routeros_wifi_steering.steering1 '*1'

--- a/examples/resources/routeros_wifi_steering/resource.tf
+++ b/examples/resources/routeros_wifi_steering/resource.tf
@@ -1,0 +1,4 @@
+resource "routeros_wifi_steering" "steering1" {
+  name           = "steering1"
+  neighbor_group = ["something"]
+}

--- a/routeros/provider.go
+++ b/routeros/provider.go
@@ -224,6 +224,7 @@ func Provider() *schema.Provider {
 			"routeros_wifi_channel":      ResourceWifiChannel(),
 			"routeros_wifi_datapath":     ResourceWifiDatapath(),
 			"routeros_wifi_interworking": ResourceWifiInterworking(),
+			"routeros_wifi_provisioning": ResourceWifiProvisioning(),
 			"routeros_wifi_security":     ResourceWifiSecurity(),
 			"routeros_wifi_steering":     ResourceWifiSteering(),
 		},

--- a/routeros/provider.go
+++ b/routeros/provider.go
@@ -219,14 +219,15 @@ func Provider() *schema.Provider {
 			"routeros_user_manager_user_profile":       ResourceUserManagerUserProfile(),
 
 			// WiFi
-			"routeros_wifi_aaa":          ResourceWifiAaa(),
-			"routeros_wifi_access_list":  ResourceWifiAccessList(),
-			"routeros_wifi_channel":      ResourceWifiChannel(),
-			"routeros_wifi_datapath":     ResourceWifiDatapath(),
-			"routeros_wifi_interworking": ResourceWifiInterworking(),
-			"routeros_wifi_provisioning": ResourceWifiProvisioning(),
-			"routeros_wifi_security":     ResourceWifiSecurity(),
-			"routeros_wifi_steering":     ResourceWifiSteering(),
+			"routeros_wifi_aaa":           ResourceWifiAaa(),
+			"routeros_wifi_access_list":   ResourceWifiAccessList(),
+			"routeros_wifi_channel":       ResourceWifiChannel(),
+			"routeros_wifi_configuration": ResourceWifiConfiguration(),
+			"routeros_wifi_datapath":      ResourceWifiDatapath(),
+			"routeros_wifi_interworking":  ResourceWifiInterworking(),
+			"routeros_wifi_provisioning":  ResourceWifiProvisioning(),
+			"routeros_wifi_security":      ResourceWifiSecurity(),
+			"routeros_wifi_steering":      ResourceWifiSteering(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"routeros_firewall":              DatasourceFirewall(),

--- a/routeros/provider.go
+++ b/routeros/provider.go
@@ -224,6 +224,7 @@ func Provider() *schema.Provider {
 			"routeros_wifi_datapath":     ResourceWifiDatapath(),
 			"routeros_wifi_interworking": ResourceWifiInterworking(),
 			"routeros_wifi_security":     ResourceWifiSecurity(),
+			"routeros_wifi_steering":     ResourceWifiSteering(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"routeros_firewall":              DatasourceFirewall(),

--- a/routeros/provider.go
+++ b/routeros/provider.go
@@ -219,6 +219,7 @@ func Provider() *schema.Provider {
 			"routeros_user_manager_user_profile":       ResourceUserManagerUserProfile(),
 
 			// WiFi
+			"routeros_wifi_aaa":      ResourceWifiAaa(),
 			"routeros_wifi_channel":  ResourceWifiChannel(),
 			"routeros_wifi_security": ResourceWifiSecurity(),
 		},

--- a/routeros/provider.go
+++ b/routeros/provider.go
@@ -219,10 +219,11 @@ func Provider() *schema.Provider {
 			"routeros_user_manager_user_profile":       ResourceUserManagerUserProfile(),
 
 			// WiFi
-			"routeros_wifi_aaa":      ResourceWifiAaa(),
-			"routeros_wifi_channel":  ResourceWifiChannel(),
-			"routeros_wifi_datapath": ResourceWifiDatapath(),
-			"routeros_wifi_security": ResourceWifiSecurity(),
+			"routeros_wifi_aaa":          ResourceWifiAaa(),
+			"routeros_wifi_channel":      ResourceWifiChannel(),
+			"routeros_wifi_datapath":     ResourceWifiDatapath(),
+			"routeros_wifi_interworking": ResourceWifiInterworking(),
+			"routeros_wifi_security":     ResourceWifiSecurity(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"routeros_firewall":              DatasourceFirewall(),

--- a/routeros/provider.go
+++ b/routeros/provider.go
@@ -221,6 +221,7 @@ func Provider() *schema.Provider {
 			// WiFi
 			"routeros_wifi_aaa":           ResourceWifiAaa(),
 			"routeros_wifi_access_list":   ResourceWifiAccessList(),
+			"routeros_wifi_capsman":       ResourceWifiCapsman(),
 			"routeros_wifi_channel":       ResourceWifiChannel(),
 			"routeros_wifi_configuration": ResourceWifiConfiguration(),
 			"routeros_wifi_datapath":      ResourceWifiDatapath(),

--- a/routeros/provider.go
+++ b/routeros/provider.go
@@ -163,11 +163,6 @@ func Provider() *schema.Provider {
 			"routeros_identity":  ResourceSystemIdentity(),
 			"routeros_scheduler": ResourceSystemScheduler(),
 
-			// TODO: Review whether capsman resources need updating given wifiwave2.
-			// wifiwave2 is getting support for capsman in 7.8.
-			// Should we support both legacy capsman _and_ wifiwave2 capsman?
-			// https://help.mikrotik.com/docs/display/ROS/WifiWave2#WifiWave2-WifiWave2CAPsMAN
-
 			// CAPsMAN Objects
 			"routeros_capsman_access_list":       ResourceCapsManAccessList(),
 			"routeros_capsman_channel":           ResourceCapsManChannel(),
@@ -208,6 +203,7 @@ func Provider() *schema.Provider {
 
 			// Helpers
 			"routeros_wireguard_keys": ResourceWireguardKeys(),
+			"routeros_move_items": ResourceMoveItems(),
 
 			// User Manager
 			"routeros_user_manager_advanced":           ResourceUserManagerAdvanced(),
@@ -222,7 +218,8 @@ func Provider() *schema.Provider {
 			"routeros_user_manager_user_group":         ResourceUserManagerUserGroup(),
 			"routeros_user_manager_user_profile":       ResourceUserManagerUserProfile(),
 
-			"routeros_move_items": ResourceMoveItems(),
+			// WiFi
+			"routeros_wifi_channel":  ResourceWifiChannel(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"routeros_firewall":              DatasourceFirewall(),

--- a/routeros/provider.go
+++ b/routeros/provider.go
@@ -221,6 +221,7 @@ func Provider() *schema.Provider {
 			// WiFi
 			"routeros_wifi_aaa":           ResourceWifiAaa(),
 			"routeros_wifi_access_list":   ResourceWifiAccessList(),
+			"routeros_wifi_cap":           ResourceWifiCap(),
 			"routeros_wifi_capsman":       ResourceWifiCapsman(),
 			"routeros_wifi_channel":       ResourceWifiChannel(),
 			"routeros_wifi_configuration": ResourceWifiConfiguration(),

--- a/routeros/provider.go
+++ b/routeros/provider.go
@@ -221,6 +221,7 @@ func Provider() *schema.Provider {
 			// WiFi
 			"routeros_wifi_aaa":      ResourceWifiAaa(),
 			"routeros_wifi_channel":  ResourceWifiChannel(),
+			"routeros_wifi_datapath": ResourceWifiDatapath(),
 			"routeros_wifi_security": ResourceWifiSecurity(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{

--- a/routeros/provider.go
+++ b/routeros/provider.go
@@ -220,6 +220,7 @@ func Provider() *schema.Provider {
 
 			// WiFi
 			"routeros_wifi_aaa":          ResourceWifiAaa(),
+			"routeros_wifi_access_list":  ResourceWifiAccessList(),
 			"routeros_wifi_channel":      ResourceWifiChannel(),
 			"routeros_wifi_datapath":     ResourceWifiDatapath(),
 			"routeros_wifi_interworking": ResourceWifiInterworking(),

--- a/routeros/provider.go
+++ b/routeros/provider.go
@@ -220,6 +220,7 @@ func Provider() *schema.Provider {
 
 			// WiFi
 			"routeros_wifi_channel":  ResourceWifiChannel(),
+			"routeros_wifi_security": ResourceWifiSecurity(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"routeros_firewall":              DatasourceFirewall(),

--- a/routeros/resource_wifi_aaa.go
+++ b/routeros/resource_wifi_aaa.go
@@ -1,0 +1,81 @@
+package routeros
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+/*
+{
+    ".id": "*1",
+    "called-format": "II-II-II-II-II-II:S",
+    "calling-format": "AA-AA-AA-AA-AA-AA",
+    "disabled": "false",
+    "interim-update": "disabled",
+    "mac-caching": "disabled",
+    "name": "aaa1",
+    "nas-identifier": "router",
+    "password-format": "",
+    "username-format": "AA:AA:AA:AA:AA:AA"
+}
+*/
+
+// https://help.mikrotik.com/docs/display/ROS/WiFi#WiFi-AAAproperties
+func ResourceWifiAaa() *schema.Resource {
+	resSchema := map[string]*schema.Schema{
+		MetaResourcePath: PropResourcePath("/interface/wifi/aaa"),
+		MetaId:           PropId(Id),
+
+		"called_format": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Format of the `Called-Station-Id` RADIUS attribute.",
+		},
+		"calling_format": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Format of the `Calling-Station-Id` RADIUS attribute.",
+		},
+		KeyComment: PropCommentRw,
+		KeyDisabled: PropDisabledRw,
+		"interim_update": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Interval at which to send interim updates about traffic accounting to the RADIUS server.",
+		},
+		"mac_caching": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Time to cache RADIUS server replies when MAC address authentication is enabled.",
+		},
+		KeyName: PropName("Name of the AAA profile."),
+		"nas_identifier": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Value of the `NAS-Identifier` RADIUS attribute.",
+		},
+		"password_format": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Format of the `User-Password` RADIUS attribute.",
+		},
+		"username_format": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Format of the `User-Name` RADIUS attribute.",
+		},
+	}
+
+	return &schema.Resource{
+		Description:   `*<span style="color:red">This resource requires a minimum version of RouterOS 7.13.</span>*`,
+		CreateContext: DefaultCreate(resSchema),
+		ReadContext:   DefaultRead(resSchema),
+		UpdateContext: DefaultUpdate(resSchema),
+		DeleteContext: DefaultDelete(resSchema),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: resSchema,
+	}
+}

--- a/routeros/resource_wifi_access_list.go
+++ b/routeros/resource_wifi_access_list.go
@@ -1,0 +1,125 @@
+package routeros
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+/*
+{
+    ".id": "*1",
+    "action": "accept",
+    "allow-signal-out-of-range": "always",
+    "client-isolation": "true",
+    "disabled": "false",
+    "interface": "2ghz",
+    "mac-address": "00:00:00:00:00:00",
+    "mac-address-mask": "00:00:00:00:00:00",
+    "passphrase": "password",
+    "radius-accounting": "true",
+    "signal-range": "-120..-85",
+    "ssid-regexp": "something",
+    "time": "6m-20m,sun,sat",
+    "vlan-id": "none"
+}
+*/
+
+// https://help.mikrotik.com/docs/display/ROS/WiFi#WiFi-AccessList.1
+func ResourceWifiAccessList() *schema.Resource {
+	resSchema := map[string]*schema.Schema{
+		MetaResourcePath: PropResourcePath("/interface/wifi/access-list"),
+		MetaId:           PropId(Id),
+
+		"action": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "accept",
+			Description: "An action to take when a client matches.",
+			ValidateFunc: validation.StringInSlice([]string{"accept", "reject", "query-radius"}, false),
+		},
+		"allow_signal_out_of_range": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "An option that permits the client's signal to be out of the range always or for some time interval.",
+		},
+		"client_isolation": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "An option that specifies whether to deny forwarding data between clients connected to the same interface.",
+		},
+		KeyComment: PropCommentRw,
+		KeyDisabled: PropDisabledRw,
+		"interface": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Interface name to compare with an interface to which the client actually connects to.",
+		},
+		"mac_address": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "MAC address of the client.",
+			ValidateFunc: ValidationMacAddress,
+		},
+		"mac_address_mask": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "MAC address mask to apply when comparing clients' addresses.",
+		},
+		KeyPlaceBefore: PropPlaceBefore,
+		"passphrase": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "PSK passphrase for the client if some PSK authentication algorithm is used.",
+		},
+		"radius_accounting": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "An option that specifies if RADIUS traffic accounting should be used in case of RADIUS authentication of the client.",
+		},
+		"signal_range": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The range in which the client signal must fall.",
+		},
+		"ssid_regexp": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "The regular expression to compare the actual SSID the client connects to.",
+		},
+		"time": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Time of the day and days of the week when the rule is applicable.",
+		},
+		"vlan_id": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "VLAN ID to use for VLAN tagging or `none`.",
+			ValidateFunc: validation.IntBetween(1, 4094),
+		},
+	}
+
+	return &schema.Resource{
+		Description:   `*<span style="color:red">This resource requires a minimum version of RouterOS 7.13.</span>*`,
+		CreateContext: DefaultCreate(resSchema),
+		ReadContext:   DefaultRead(resSchema),
+		UpdateContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+			resSchema[MetaSkipFields].Default = `"place_before"`
+			defer func() {
+				resSchema[MetaSkipFields].Default = ``
+			}()
+
+			return ResourceUpdate(ctx, resSchema, d, m)
+		},
+		DeleteContext: DefaultDelete(resSchema),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: resSchema,
+	}
+}

--- a/routeros/resource_wifi_cap.go
+++ b/routeros/resource_wifi_cap.go
@@ -1,0 +1,105 @@
+package routeros
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+/*
+{
+    "caps-man-addresses": "192.168.88.1",
+    "caps-man-certificate-common-names": "CAPsMAN-0000000",
+    "caps-man-names": "router",
+    "certificate": "request",
+    "discovery-interfaces": "lan",
+    "enabled": "no",
+    "lock-to-caps-man": "true",
+    "slaves-datapath": "lan",
+    "slaves-static": "true"
+}
+*/
+
+// https://help.mikrotik.com/docs/display/ROS/WiFi#WiFi-CAPconfiguration
+func ResourceWifiCap() *schema.Resource {
+	resSchema := map[string]*schema.Schema{
+		MetaResourcePath: PropResourcePath("/interface/wifi/cap"),
+		MetaId:           PropId(Name),
+
+		"caps_man_addresses": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{
+				Type:         schema.TypeString,
+				ValidateFunc: validation.IsIPAddress,
+			},
+			Description: "List of Manager IP addresses that CAP will attempt to contact during discovery.",
+		},
+		"caps_man_certificate_common_names": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "List of manager certificate common names that CAP will connect to.",
+		},
+		"caps_man_names": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "An ordered list of CAPs Manager names that the CAP will connect to.",
+		},
+		"certificate": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Certificate to use for authentication.",
+		},
+		"discovery_interfaces": {
+			Type:        schema.TypeSet,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "List of interfaces over which CAP should attempt to discover CAPs Manager.",
+		},
+		"enabled": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Disable or enable the CAP functionality.",
+		},
+		"lock_to_caps_man": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Lock CAP to the first CAPsMAN it connects to.",
+		},
+		"locked_caps_man_common_name": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Common name of the CAPsMAN that the CAP is locked to.",
+		},
+		"requested_certificate": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Requested certificate.",
+		},
+		"slaves_datapath": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Name of the bridge interface the CAP will be added to.",
+		},
+		"slaves_static": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "An option that creates static virtual interfaces.",
+		},
+	}
+
+	return &schema.Resource{
+		Description:   `*<span style="color:red">This resource requires a minimum version of RouterOS 7.13.</span>*`,
+		CreateContext: DefaultSystemCreate(resSchema),
+		ReadContext:   DefaultSystemRead(resSchema),
+		UpdateContext: DefaultSystemUpdate(resSchema),
+		DeleteContext: DefaultSystemDelete(resSchema),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: resSchema,
+	}
+}

--- a/routeros/resource_wifi_capsman.go
+++ b/routeros/resource_wifi_capsman.go
@@ -1,0 +1,92 @@
+package routeros
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+/*
+{
+    "ca-certificate": "auto",
+    "certificate": "auto",
+    "enabled": "yes",
+    "generated-ca-certificate": "WiFi-CAPsMAN-CA-000000000000",
+    "generated-certificate": "WiFi-CAPsMAN-000000000000",
+    "interfaces": "LAN",
+    "package-path": "/upgrade",
+    "require-peer-certificate": "true",
+    "upgrade-policy": "suggest-same-version"
+}
+*/
+
+// https://help.mikrotik.com/docs/display/ROS/WiFi#WiFi-CAPsMANGlobalConfiguration
+func ResourceWifiCapsman() *schema.Resource {
+	resSchema := map[string]*schema.Schema{
+		MetaResourcePath: PropResourcePath("/interface/wifi/capsman"),
+		MetaId:           PropId(Name),
+
+		"ca_certificate": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Device CA certificate.",
+		},
+		"certificate": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Device certificate.",
+		},
+		"enabled": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Disable or enable CAPsMAN functionality.",
+		},
+		"generated_ca_certificate": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Generated CA certificate.",
+		},
+		"generated_certificate": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Generated CAPsMAN certificate.",
+		},
+		"interfaces": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "List of interfaces on which CAPsMAN will listen for CAP connections.",
+		},
+		"package_path": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Folder location for the RouterOS packages. For example, use '/upgrade' to specify the " +
+				"upgrade folder from the files section. If empty string is set, CAPsMAN can use built-in RouterOS " +
+				"packages, note that in this case only CAPs with the same architecture as CAPsMAN will be upgraded.",
+		},
+		"require_peer_certificate": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Require all connecting CAPs to have a valid certificate.",
+		},
+		"upgrade_policy": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "Upgrade policy options.",
+			ValidateFunc: validation.StringInSlice([]string{"none", "require-same-version", "suggest-same-version"}, false),
+		},
+	}
+
+	return &schema.Resource{
+		Description:   `*<span style="color:red">This resource requires a minimum version of RouterOS 7.13.</span>*`,
+		CreateContext: DefaultSystemCreate(resSchema),
+		ReadContext:   DefaultSystemRead(resSchema),
+		UpdateContext: DefaultSystemUpdate(resSchema),
+		DeleteContext: DefaultSystemDelete(resSchema),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: resSchema,
+	}
+}

--- a/routeros/resource_wifi_channel.go
+++ b/routeros/resource_wifi_channel.go
@@ -1,0 +1,76 @@
+package routeros
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+/*
+{
+    ".id": "*1",
+    "band": "2ghz-n",
+    "disabled": "false",
+    "frequency": "2412",
+    "name": "channel1",
+    "secondary-frequency": "disabled",
+    "skip-dfs-channels": "disabled",
+    "width": "20mhz"
+}
+*/
+
+// https://help.mikrotik.com/docs/display/ROS/WiFi#WiFi-Channelproperties
+func ResourceWifiChannel() *schema.Resource {
+	resSchema := map[string]*schema.Schema{
+		MetaResourcePath: PropResourcePath("/interface/wifi/channel"),
+		MetaId:           PropId(Id),
+
+		"band": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Frequency band and wireless standard that will be used by the AP. ",
+			ValidateFunc: validation.StringInSlice([]string{"2ghz-g", "2ghz-n", "2ghz-ax", "5ghz-a", "5ghz-ac", "5ghz-an", "5ghz-ax"}, false),
+		},
+		KeyComment:  PropCommentRw,
+		KeyDisabled: PropDisabledRw,
+		"frequency": {
+			Type:        schema.TypeList,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Optional:    true,
+			Description: "Channel frequency value or range in MHz on which AP or station will operate.",
+		},
+		KeyName: PropName("Name of the channel."),
+		"secondary_frequency": {
+			Type:        schema.TypeList,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Optional:    true,
+			Description: "Specifies the second frequency that will be used for 80+80MHz configuration. " +
+				"Set it to `disabled` in order to disable 80+80MHz capability.",
+		},
+		"skip_dfs_channels": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "An option to avoid using channels on which channel availability check (listening for the presence of radar signals) is required.",
+			ValidateFunc: validation.StringInSlice([]string{"10min-cac", "all", "disabled"}, false),
+		},
+		"width": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "Channel width.",
+			ValidateFunc: validation.StringInSlice([]string{"20mhz", "20/40mhz", "20/40mhz-Ce", "20/40mhz-eC", "20/40/80mhz", "20/40/80+80mhz", "20/40/80/160mhz"}, false),
+		},
+	}
+
+	return &schema.Resource{
+		Description:   `*<span style="color:red">This resource requires a minimum version of RouterOS 7.13.</span>*`,
+		CreateContext: DefaultCreate(resSchema),
+		ReadContext:   DefaultRead(resSchema),
+		UpdateContext: DefaultUpdate(resSchema),
+		DeleteContext: DefaultDelete(resSchema),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: resSchema,
+	}
+}

--- a/routeros/resource_wifi_configuration.go
+++ b/routeros/resource_wifi_configuration.go
@@ -1,0 +1,181 @@
+package routeros
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+/*
+{
+    ".id": "*3",
+    "aaa": "aaa1",
+    "antenna-gain": "10",
+    "beacon-interval": "1s",
+    "chains": "0,1,2,3",
+    "channel": "channel1",
+    "country": "Netherlands",
+    "datapath": "datapath1",
+    "disabled": "false",
+    "dtim-period": "1",
+    "hide-ssid": "true",
+    "interworking": "interworking1",
+    "manager": "capsman",
+    "mode": "ap",
+    "multicast-enhance": "disabled",
+    "name": "cfg1",
+    "qos-classifier": "priority",
+    "security": "security1",
+    "security.connect-priority": "0",
+    "ssid": "test",
+    "steering": "steering1",
+    "tx-chains": "4,5,6,7",
+    "tx-power": "10"
+}
+*/
+
+// https://help.mikrotik.com/docs/display/ROS/WiFi#WiFi-Configurationproperties
+func ResourceWifiConfiguration() *schema.Resource {
+	resSchema := map[string]*schema.Schema{
+		MetaResourcePath: PropResourcePath("/interface/wifi/configuration"),
+		MetaId:           PropId(Id),
+		MetaTransformSet: PropTransformSet(`"aaa": "aaa.config", "channel": "channel.config", "datapath": "datapath.config",
+		"interworking": "interworking.config", "security": "security.config", "steering": "steering.config"`),
+
+		"aaa": {
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Elem: &schema.Schema{Type: schema.TypeString},
+			Description: "AAA inline settings.",
+		},
+		"antenna_gain": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Description:  "An option overrides the default antenna gain.",
+			ValidateFunc: validation.IntBetween(0, 30),
+		},
+		"beacon_interval": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Time interval between beacon frames.",
+			DiffSuppressFunc: TimeEquall,
+		},
+		"chains": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type:         schema.TypeInt,
+				ValidateFunc: validation.IntBetween(0, 7),
+			},
+			Description: "Radio chains to use for receiving signals.",
+		},
+		"channel": {
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "Channel inline settings.",
+		},
+		KeyComment: PropCommentRw,
+		"country": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "An option determines which regulatory domain restrictions are applied to an interface.",
+		},
+		"datapath": {
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "Datapath inline settings.",
+		},
+		KeyDisabled: PropDisabledRw,
+		"dtim_period": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Description:  "A period at which to transmit multicast traffic, when there are client devices in power save mode connected to the AP.",
+			ValidateFunc: validation.IntBetween(1, 255),
+		},
+		"hide_ssid": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Description: "This property has effect only in AP mode. Setting it to yes can remove this network from " +
+				"the list of wireless networks that are shown by some client software. Changing this setting does not " +
+				"improve the security of the wireless network, because SSID is included in other frames sent by the AP.",
+		},
+		"interworking": {
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "Interworking inline settings.",
+		},
+		"manager": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "An option to specify the remote CAP mode.",
+			ValidateFunc: validation.StringInSlice([]string{"capsman", "capsman-or-local", "local"}, false),
+		},
+		"mode": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "An option to specify the access point operational mode.",
+			ValidateFunc: validation.StringInSlice([]string{"ap", "station", "station-bridge"}, false),
+		},
+		"multicast_enhance": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "An option to enable converting every multicast-address IP or IPv6 packet into multiple unicast-addresses frames for each connected station.",
+			ValidateFunc: validation.StringInSlice([]string{"disabled", "enabled"}, false),
+		},
+		KeyName: PropName("Name of the configuration."),
+		"qos_classifier": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "An option to specify the QoS classifier.",
+			ValidateFunc: validation.StringInSlice([]string{"dscp-high-3-bits", "priority"}, false),
+		},
+		"security": {
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "Security inline settings.",
+		},
+		"ssid": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "SSID (service set identifier) is a name broadcast in the beacons that identifies wireless network.",
+		},
+		"steering": {
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "Steering inline settings.",
+		},
+		"tx_chains": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type:         schema.TypeInt,
+				ValidateFunc: validation.IntBetween(0, 7),
+			},
+			Description: "Radio chains to use for transmitting signals.",
+		},
+		"tx_power": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Description:  "A limit on the transmit power (in dBm) of the interface.",
+			ValidateFunc: validation.IntBetween(0, 40),
+		},
+	}
+
+	return &schema.Resource{
+		Description:   `*<span style="color:red">This resource requires a minimum version of RouterOS 7.13.</span>*`,
+		CreateContext: DefaultCreate(resSchema),
+		ReadContext:   DefaultRead(resSchema),
+		UpdateContext: DefaultUpdate(resSchema),
+		DeleteContext: DefaultDelete(resSchema),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: resSchema,
+	}
+}

--- a/routeros/resource_wifi_datapath.go
+++ b/routeros/resource_wifi_datapath.go
@@ -1,0 +1,75 @@
+package routeros
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+/*
+{
+    ".id": "*1",
+    "bridge": "lan",
+    "bridge-cost": "1",
+    "bridge-horizon": "none",
+    "client-isolation": "true",
+    "disabled": "false",
+    "interface-list": "LAN",
+    "name": "datapath1",
+    "vlan-id": "1"
+}
+*/
+
+// https://help.mikrotik.com/docs/display/ROS/WiFi#WiFi-Datapathproperties
+func ResourceWifiDatapath() *schema.Resource {
+	resSchema := map[string]*schema.Schema{
+		MetaResourcePath: PropResourcePath("/interface/wifi/datapath"),
+		MetaId:           PropId(Id),
+
+		"bridge": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Bridge interface to add the interface as a bridge port.",
+		},
+		"bridge_cost": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Spanning tree protocol cost of the bridge port.",
+		},
+		"bridge_horizon": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Bridge horizon to use when adding as a bridge port.",
+		},
+		"client_isolation": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "An option to toggle communication between clients connected to the same AP.",
+		},
+		KeyComment: PropCommentRw,
+		KeyDisabled: PropDisabledRw,
+		"interface_list": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "List to which add the interface as a member.",
+		},
+		KeyName: PropName("Name of the datapath."),
+		"vlan_id": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Default VLAN ID to assign to client devices connecting to this interface.",
+		},
+	}
+
+	return &schema.Resource{
+		Description:   `*<span style="color:red">This resource requires a minimum version of RouterOS 7.13.</span>*`,
+		CreateContext: DefaultCreate(resSchema),
+		ReadContext:   DefaultRead(resSchema),
+		UpdateContext: DefaultUpdate(resSchema),
+		DeleteContext: DefaultDelete(resSchema),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: resSchema,
+	}
+}

--- a/routeros/resource_wifi_interworking.go
+++ b/routeros/resource_wifi_interworking.go
@@ -1,0 +1,233 @@
+package routeros
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+/*
+{
+    ".id": "*1",
+    "3gpp-info": "12",
+    "authentication-types": "terms-and-conditions,terms-and-conditions",
+    "disabled": "false",
+    "domain-names": "example.com,www.example.com",
+    "esr": "true",
+    "hessid": "00:00:00:00:00:00",
+    "hotspot20": "true",
+    "hotspot20-dgaf": "true",
+    "internet": "true",
+    "ipv4-availability": "not-available",
+    "ipv6-availability": "unknown",
+    "name": "interworking1",
+    "network-type": "private",
+    "operational-classes": "10,11",
+    "operator-names": "name1,name2",
+    "realms": "something1:not-specified,something2:eap-sim",
+    "roaming-ois": "something1,something2",
+    "uesa": "true",
+    "venue": "unspecified",
+    "venue-names": "name1,name2",
+    "wan-at-capacity": "true",
+    "wan-downlink": "10",
+    "wan-downlink-load": "5",
+    "wan-measurement-duration": "10",
+    "wan-status": "reserved",
+    "wan-symmetric": "true",
+    "wan-uplink": "2",
+    "wan-uplink-load": "1"
+}
+*/
+
+// https://help.mikrotik.com/docs/display/ROS/Interworking+Profiles
+func ResourceWifiInterworking() *schema.Resource {
+	resSchema := map[string]*schema.Schema{
+		MetaResourcePath: PropResourcePath("/interface/wifi/interworking"),
+		MetaId:           PropId(Id),
+
+		"3gpp_info": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "Cellular network advertisement information - country and network codes.",
+		},
+		"3gpp_raw": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Cellular network advertisement information - country and network codes.",
+		},
+		"asra": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "An option to enable Additional Steps Required for Access.",
+		},
+		"authentication_types": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "A list of authentication types that is only effective when `asra` is set to yes.",
+		},
+		KeyComment: PropCommentRw,
+		"connection_capabilities": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "A list to provide information about the allowed IP protocols and ports.",
+		},
+		KeyDisabled: PropDisabledRw,
+		"domain_names": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "A list of fully qualified domain names (FQDN) that indicate the entity operating the Hotspot.",
+		},
+		"esr": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "An option to enable Emergency Services Reachability.",
+		},
+		"hessid": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Homogenous extended service set identifier (HESSID).",
+		},
+		"hotspot20": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "An option to indicate Hotspot 2.0 capability of the Access Point.",
+		},
+		"hotspot20_dgaf": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "An option to indicate Downstream Group-Addressed Forwarding (DGAF) capability.",
+		},
+		"internet": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "An option to indicate Internet availability.",
+		},
+		"ipv4_availability": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "An option to indicate IPv4 availability.",
+			ValidateFunc: validation.StringInSlice([]string{"double-nated", "not-available", "port-restricted", "port-restricted-double-nated", "port-restricted-single-nated", "public", "single-nated", "unknown"}, false),
+		},
+		"ipv6_availability": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "An option to indicate IPv6 availability.",
+			ValidateFunc: validation.StringInSlice([]string{"available", "not-available", "unknown"}, false),
+		},
+		KeyName: PropName("Name of the interworking profile."),
+		"network_type": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "Information about network access type.",
+			ValidateFunc: validation.StringInSlice([]string{"emergency-only", "personal-device", "private", "private-with-guest", "public-chargeable", "public-free", "test", "wildcard"}, false),
+		},
+		"operational_classes": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeInt},
+			Description: "A list with information about other available bands.",
+		},
+		"operator_names": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "A list of colon-separated operator names and language codes.",
+		},
+		"realms": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "A list of colon-separated realm names and EAP methods.",
+		},
+		"realms_raw": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "A list of 'NAI Realm Tuple' excluding 'NAI Realm Data Field Length' field.",
+		},
+		"roaming_ois": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "A list of Organization Identifiers (OI).",
+		},
+		"uesa": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "An option to enable Unauthenticated Emergency Service Accessibility.",
+		},
+		"venue": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "Information about the venue in which the Access Point is located.",
+		},
+		"venue_names": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "A list of colon-separated venue names and language codes.",
+		},
+		"wan_at_capacity": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "An option to indicate that the Access Point or the network is at its max capacity.",
+		},
+		"wan_downlink": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Description: "The downlink speed of the WAN connection set in kbps.",
+		},
+		"wan_downlink_load": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Description:  "The downlink load of the WAN connection measured over `wan_measurement_duration`.",
+			ValidateFunc: validation.IntBetween(0, 255),
+		},
+		"wan_measurement_duration": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Description: "The duration during which `wan_downlink_load` and `wan_uplink_load` are measured.",
+			ValidateFunc: validation.IntBetween(0, 65535),
+		},
+		"wan_status": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "Information about the status of the Access Point's WAN connection.",
+			ValidateFunc: validation.StringInSlice([]string{"down", "reserved", "test", "up"}, false),
+		},
+		"wan_symmetric": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "An option to indicate that the WAN link is symmetric (upload and download speeds are the same).",
+		},
+		"wan_uplink": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Description: "The uplink speed of the WAN connection set in kbps.",
+		},
+		"wan_uplink_load": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Description:  "The uplink load of the WAN connection measured over `wan_measurement_duration`.",
+			ValidateFunc: validation.IntBetween(0, 255),
+		},
+	}
+
+	return &schema.Resource{
+		Description:   `*<span style="color:red">This resource requires a minimum version of RouterOS 7.13.</span>*`,
+		CreateContext: DefaultCreate(resSchema),
+		ReadContext:   DefaultRead(resSchema),
+		UpdateContext: DefaultUpdate(resSchema),
+		DeleteContext: DefaultDelete(resSchema),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: resSchema,
+	}
+}

--- a/routeros/resource_wifi_provisioning.go
+++ b/routeros/resource_wifi_provisioning.go
@@ -1,0 +1,105 @@
+package routeros
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+/*
+{
+    ".id": "*1",
+    "action": "create-enabled",
+    "address-ranges": "192.168.88.1-192.168.88.100,192.168.100.1-192.168.100.100",
+    "common-name-regexp": "test",
+    "disabled": "false",
+    "identity-regexp": "test",
+    "master-configuration": "cfg1",
+    "name-format": "cap1:",
+    "radio-mac": "00:00:00:00:00:00",
+    "slave-configurations": "cfg1",
+    "supported-bands": "2ghz-n,2ghz-g"
+}
+*/
+
+// https://help.mikrotik.com/docs/display/ROS/WiFi#WiFi-CAPsMANProvisioning
+func ResourceWifiProvisioning() *schema.Resource {
+	resSchema := map[string]*schema.Schema{
+		MetaResourcePath: PropResourcePath("/interface/wifi/provisioning"),
+		MetaId:           PropId(Id),
+
+		"action": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "none",
+			Description: "Provisioning action.",
+			ValidateFunc: validation.StringInSlice([]string{"create-disabled", "create-enabled",
+				"create-dynamic-enabled", "none"}, false),
+		},
+		"address_ranges": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "Match CAPs by IPs within configured address ranges.",
+		},
+		KeyComment: PropCommentRw,
+		"common_name_regexp": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Regular expression to match radios by common name.",
+		},
+		KeyDisabled: PropDisabledRw,
+		"identity_regexp": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Regular expression to match radios by router identity.",
+		},
+		"master_configuration": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "If action specifies to create interfaces, then a new master interface with its configuration " +
+				"set to this configuration profile will be created.",
+		},
+		"name_format": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "Specify the format of the CAP interface name creation.",
+		},
+		"radio_mac": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Default:      "00:00:00:00:00:00",
+			Description:  "MAC address of radio to be matched, empty MAC (00:00:00:00:00:00) means match all MAC addresses.",
+			ValidateFunc: ValidationMacAddress,
+		},
+		"slave_configurations": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+			Description: "If action specifies to create interfaces, then a new slave interface for each configuration " +
+				"profile in this list is created.",
+		},
+		"supported_bands": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+				ValidateFunc: validation.StringInSlice([]string{"2ghz-ax", "2ghz-g", "2ghz-n", "5ghz-a", "5ghz-ac", "5ghz-ax", "5ghz-n"}, false),
+			},
+			Description: "Match CAPs by supported modes.",
+		},
+	}
+
+	return &schema.Resource{
+		Description:   `*<span style="color:red">This resource requires a minimum version of RouterOS 7.13.</span>*`,
+		CreateContext: DefaultCreate(resSchema),
+		ReadContext:   DefaultRead(resSchema),
+		UpdateContext: DefaultUpdate(resSchema),
+		DeleteContext: DefaultDelete(resSchema),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: resSchema,
+	}
+}

--- a/routeros/resource_wifi_security.go
+++ b/routeros/resource_wifi_security.go
@@ -1,0 +1,249 @@
+package routeros
+
+import (
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+/*
+{
+    ".id": "*1",
+    "authentication-types": "wpa2-psk,wpa3-psk",
+    "connect-group": "something",
+    "connect-priority": "0",
+    "dh-groups": "19,20,21",
+    "disable-pmkid": "false",
+    "disabled": "false",
+    "eap-accounting": "true",
+    "eap-anonymous-identity": "anonymous",
+    "eap-certificate-mode": "verify-certificate",
+    "eap-methods": "peap,tls",
+    "eap-password": "",
+    "eap-tls-certificate": "ca",
+    "eap-username": "",
+    "encryption": "tkip",
+    "ft": "true",
+    "ft-mobility-domain": "0x1",
+    "ft-nas-identifier": "ssid",
+    "ft-over-ds": "true",
+    "ft-preserve-vlanid ": "true",
+    "ft-r0-key-lifetime": "10m",
+    "ft-reassociation-deadline": "10s",
+    "group-encryption": "tkip",
+    "group-key-update": "10m",
+    "management-encryption": "cmac",
+    "management-protection": "disabled",
+    "name": "sec1",
+    "passphrase": "passphrase",
+    "sae-anti-clogging-threshold": "0",
+    "sae-max-failure-rate": "disabled",
+    "sae-pwe": "hunting-and-pecking",
+    "wps": "disable"
+}
+*/
+
+// https://help.mikrotik.com/docs/display/ROS/WiFi#WiFi-SecurityProperties
+func ResourceWifiSecurity() *schema.Resource {
+	resSchema := map[string]*schema.Schema{
+		MetaResourcePath: PropResourcePath("/interface/wifi/security"),
+		MetaId:           PropId(Id),
+
+		"authentication_types": {
+			Type:        schema.TypeSet,
+			Optional:    true,
+			Elem:        &schema.Schema{
+				Type:         schema.TypeString,
+				ValidateFunc: validation.StringInSlice([]string{"wpa-psk", "wpa2-psk", "wpa-eap", "wpa2-eap", "wpa3-psk", "owe", "wpa3-eap", "wpa3-eap-192"}, false),
+			},
+			Description: "Authentication types to enable on the interface.",
+		},
+		KeyComment: PropCommentRw,
+		"connect_group": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "APs within the same connect group do not allow more than 1 client device with the same MAC address.",
+		},
+		"connect_priority": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "An option to determine how a connection is handled if the MAC address of the client device is the same as that of another active connection to another AP.",
+		},
+		"dh_groups": {
+			Type:        schema.TypeSet,
+			Optional:    true,
+			Elem:        &schema.Schema{
+				Type:         schema.TypeInt,
+				ValidateFunc: validation.IntInSlice([]int{19, 20, 21}),
+			},
+			Description: "Identifiers of elliptic curve cryptography groups to use in SAE (WPA3) authentication.",
+		},
+		"disable_pmkid": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "An option to disable inclusion of a PMKID in EAPOL frames.",
+		},
+		KeyDisabled: PropDisabledRw,
+		"eap_accounting": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "An option to send accounting information to RADIUS server for EAP-authenticated peers.",
+		},
+		"eap_anonymous_identity": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "An option to specify anonymous identity for EAP outer authentication.",
+		},
+		"eap_certificate_mode": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "A policy for handling the TLS certificate of the RADIUS server.",
+			ValidateFunc: validation.StringInSlice([]string{"dont-verify-certificate", "no-certificates", "verify-certificate", "verify-certificate-with-crl"}, false),
+		},
+		"eap_methods": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type:         schema.TypeString,
+				ValidateFunc: validation.StringInSlice([]string{"peap", "tls", "ttls"}, false),
+			},
+			Description: "A set of EAP methods to consider for authentication.",
+		},
+		"eap_password": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Password to use when the chosen EAP method requires one.",
+		},
+		"eap_tls_certificate": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Name or id of a certificate in the device's certificate store to use when the chosen EAP authentication method requires one.",
+		},
+		"eap_username": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Username to use when the chosen EAP method requires one. ",
+		},
+		"encryption": {
+			Type:         schema.TypeSet,
+			Optional:     true,
+			Elem:         &schema.Schema{
+				Type:         schema.TypeString,
+				ValidateFunc: validation.StringInSlice([]string{"ccmp", "ccmp-256", "gcmp", "gcmp-256", "tkip"}, false),
+			},
+			Description: "A list of ciphers to support for encrypting unicast traffic.",
+		},
+		"ft": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "An option to enable 802.11r fast BSS transitions (roaming).",
+		},
+		"ft_mobility_domain": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Description:  "The fast BSS transition mobility domain ID.",
+			ValidateFunc: validation.IntBetween(0, 65535),
+		},
+		"ft_nas_identifier": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "Fast BSS transition PMK-R0 key holder identifier.",
+			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[0-9a-zA-Z]{2,96}$`),
+				"Must be a string of 2 - 96 hex characters."),
+		},
+		"ft_over_ds": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "An option to enable fast BSS transitions over DS (distributed system).",
+		},
+		"ft_preserve_vlanid": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "An option to preserve VLAN ID when roaming.",
+		},
+		"ft_r0_key_lifetime": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "The lifetime of the fast BSS transition PMK-R0 encryption key.",
+			DiffSuppressFunc: TimeEquall,
+		},
+		"ft_reassociation_deadline": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Fast BSS transition reassociation deadline.",
+			DiffSuppressFunc: TimeEquall,
+		},
+		"group_encryption": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "A cipher to use for encrypting multicast traffic.",
+			ValidateFunc: validation.StringInSlice([]string{"ccmp", "ccmp-256", "gcmp", "gcmp-256", "tkip"}, false),
+		},
+		"group_key_update": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "The interval at which the group temporal key (key for encrypting broadcast traffic) is renewed.",
+			DiffSuppressFunc: TimeEquall,
+		},
+		"management_encryption": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "A cipher to use for encrypting protected management frames.",
+			ValidateFunc: validation.StringInSlice([]string{"cmac", "cmac-256", "gmac", "gmac-256"}, false),
+		},
+		"management_protection": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "An option to enable 802.11w management frame protection.",
+			ValidateFunc: validation.StringInSlice([]string{"allowed", "disabled", "required"}, false),
+		},
+		"owe_transition_interface": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Name or internal ID of an interface which MAC address and SSID to advertise as the matching AP when running in OWE transition mode.",
+		},
+		KeyName: PropName("Name of the security profile."),
+		"passphrase": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Passphrase to use for PSK authentication types.",
+		},
+		"sae_anti_clogging_threshold": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "A parameter to mitigate DoS attacks by specifying a threshold of in-progress SAE authentications.",
+		},
+		"sae_max_failure_rate": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "Rate of failed SAE (WPA3) associations per minute, at which the AP will stop processing new association requests.",
+		},
+		"sae_pwe": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "Methods to support for deriving SAE password element.",
+			ValidateFunc: validation.StringInSlice([]string{"both", "hash-to-element", "hunting-and-pecking"}, false),
+		},
+		"wps": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "An option to enable WPS (Wi-Fi Protected Setup).",
+			ValidateFunc: validation.StringInSlice([]string{"disabled", "push-button"}, false),
+		},
+	}
+
+	return &schema.Resource{
+		Description:   `*<span style="color:red">This resource requires a minimum version of RouterOS 7.13.</span>*`,
+		CreateContext: DefaultCreate(resSchema),
+		ReadContext:   DefaultRead(resSchema),
+		UpdateContext: DefaultUpdate(resSchema),
+		DeleteContext: DefaultDelete(resSchema),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: resSchema,
+	}
+}

--- a/routeros/resource_wifi_steering.go
+++ b/routeros/resource_wifi_steering.go
@@ -1,0 +1,58 @@
+package routeros
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+/*
+{
+    ".id": "*1",
+    "disabled": "false",
+    "name": "steering1",
+    "neighbor-group": "something",
+    "rrm": "true",
+    "wnm": "true"
+}
+*/
+
+// https://help.mikrotik.com/docs/display/ROS/WiFi#WiFi-Steeringproperties
+func ResourceWifiSteering() *schema.Resource {
+	resSchema := map[string]*schema.Schema{
+		MetaResourcePath: PropResourcePath("/interface/wifi/steering"),
+		MetaId:           PropId(Id),
+
+		KeyComment: PropCommentRw,
+		KeyDisabled: PropDisabledRw,
+		KeyName: PropName("Name of the steering profile."),
+		"neighbor_group": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "Neighbor group of potential roaming candidates.",
+		},
+		"rrm": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "An option to enable sending 802.11k neighbor reports.",
+		},
+		"wnm": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "An option to enable sending 802.11v BSS transition management requests.",
+		},
+	}
+
+	return &schema.Resource{
+		Description:   `*<span style="color:red">This resource requires a minimum version of RouterOS 7.13.</span>*`,
+		CreateContext: DefaultCreate(resSchema),
+		ReadContext:   DefaultRead(resSchema),
+		UpdateContext: DefaultUpdate(resSchema),
+		DeleteContext: DefaultDelete(resSchema),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: resSchema,
+	}
+}


### PR DESCRIPTION
This PR adds support of the recently released [WiFi](https://help.mikrotik.com/docs/display/ROS/WiFi) package (successor of wifiwave2). This API is only available in RouterOS starting from 7.13 and hence cannot be covered with tests in the current state.

The following new resources will be added:
- `resource_wifi_aaa`;
- `resource_wifi_access_list`;
- `resource_wifi_cap`;
- `resource_wifi_capsman`;
- `resource_wifi_channel`;
- `resource_wifi_configuration`;
- `resource_wifi_datapath`;
- `resource_wifi_interworking`;
- `resource_wifi_provisioning`;
- `resource_wifi_security`;
- `resource_wifi_steering`.

Resolves #204.