### PR TITLE
fix: Fix properties validation and some missing properties

### DIFF
--- a/routeros/resource_bgp_template.go
+++ b/routeros/resource_bgp_template.go
@@ -105,6 +105,10 @@ func ResourceRoutingBGPTemplate() *schema.Resource {
 			ValidateFunc: validation.IsIPv4Address,
 		},
 		KeyComment:  PropCommentRw,
+		"default": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
 		KeyDisabled: PropDisabledRw,
 		// hold-time ( time[3s..1h] | infinity ; Default: 3m )
 		"hold_time": {

--- a/routeros/resource_capsman_manager.go
+++ b/routeros/resource_capsman_manager.go
@@ -10,6 +10,8 @@ import (
   "ca-certificate": "none",
   "certificate": "none",
   "enabled": "false",
+  "generated-ca-certificate":"CAPsMAN-CA-000000000000",
+  "generated-certificate":"CAPsMAN-000000000000",
   "package-path": "",
   "require-peer-certificate": "false",
   "upgrade-policy": "none"
@@ -39,6 +41,16 @@ func ResourceCapsManManager() *schema.Resource {
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Description: "Disable or enable CAPsMAN functionality.",
+		},
+		"generated_ca_certificate": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Generated CA certificate.",
+		},
+		"generated_certificate": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Generated CAPsMAN certificate.",
 		},
 		"package_path": {
 			Type:     schema.TypeString,

--- a/routeros/resource_interface_bridge.go
+++ b/routeros/resource_interface_bridge.go
@@ -194,6 +194,13 @@ func ResourceInterfaceBridge() *schema.Resource {
 			RequiredWith: []string{"igmp_snooping"},
 		},
 		KeyName: PropNameForceNewRw,
+		"port_cost_mode": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "An option that changes the port path cost and internal path cost mode for bridged ports, utilizing automatic values based on interface speed.",
+			ValidateFunc:     validation.StringInSlice([]string{"long", "short"}, false),
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
 		"priority": {
 			Type:     schema.TypeString,
 			Optional: true,

--- a/routeros/resource_interface_ethernet.go
+++ b/routeros/resource_interface_ethernet.go
@@ -69,9 +69,8 @@ func ResourceInterfaceEthernet() *schema.Resource {
 				Advertised speed and duplex modes for Ethernet interfaces over twisted pair, 
 				only applies when auto-negotiation is enabled. Advertising higher speeds than 
 				the actual interface supported speed will have no effect, multiple options are allowed.`,
-			ValidateFunc: validation.StringInSlice([]string{
-				"10M-full", "10M-half", "100M-full", "100M-half",
-				"1000M-full", "1000M-half", "2500M-full", "5000M-full", "10000M-full"}, false),
+			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[0-9\.]+(M|G)-(full|half|base\w+(-\w+)?)$`),
+				"Since RouterOS v7.12 the values of this property have changed. Please check the documentation."),
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		KeyArp:        PropArpRw,

--- a/routeros/resource_user_manager_router.go
+++ b/routeros/resource_user_manager_router.go
@@ -26,7 +26,7 @@ func ResourceUserManagerRouter() *schema.Resource {
 			Type:         schema.TypeString,
 			Required:     true,
 			Description:  "IP address of the RADIUS client.",
-			ValidateFunc: validation.IsIPAddress,
+			ValidateFunc: ValidationIpAddress,
 		},
 		"coa_port": {
 			Type:         schema.TypeInt,


### PR DESCRIPTION
This PR brings the following:
- adds the `default` property in `routeros_routing_bgp_template`;
- adds the `generated_ca_certificate` property in `routeros_capsman_manager`;
- adds the `generated_certificate` property in `routeros_capsman_manager`;
- fixes validation of the `advertise` property in `routeros_interface_ethernet`;
- fixes validation of the `address` property in `routeros_user_manager_router`;
- adds the `port_cost_mode` property in `routeros_interface_bridge` (resolves #333).