### PR TITLE
Add missing ethernet interface fields to SkipFields

### DIFF
--- a/routeros/resource_interface_ethernet.go
+++ b/routeros/resource_interface_ethernet.go
@@ -58,7 +58,7 @@ func ResourceInterfaceEthernet() *schema.Resource {
 				`"tx_rx_64","tx_rx_65_127","tx_rx_128_255","tx_rx_256_511","tx_rx_512_1023","tx_rx_1024_1518","tx_rx_1024_max",tx_rx_1519_max",` +
 				`"rx_broadcast","rx_bytes","rx_control","rx_drop","rx_fcs_error","rx_fragment","rx_jabber","rx_multicast","rx_packet","rx_pause","rx_too_short","rx_too_long",` +
 				`"tx_broadcast","tx_bytes","tx_control","tx_drop","tx_fcs_error","tx_fragment","tx_jabber","tx_multicast","tx_packet","tx_pause","tx_too_short","tx_too_long",` +
-				`"rx_align_error","rx_carrier_error","rx_code_error","rx_error_events","rx_length_error","rx_overflow","rx_unknown_op",` +
+				`"rx_align_error","rx_carrier_error","rx_code_error","rx_error_events","rx_length_error","rx_overflow","rx_unicast","rx_unknown_op"` +
 				`"tx_collision","tx_excessive_collision","tx_late_collision","tx_multiple_collision","tx_single_collision","tx_total_collision",` +
 				`"tx_deferred","tx_excessive_deferred","tx_unicast","tx_underrun",`,
 		),

--- a/routeros/resource_interface_ethernet.go
+++ b/routeros/resource_interface_ethernet.go
@@ -51,16 +51,16 @@ func ResourceInterfaceEthernet() *schema.Resource {
 	resSchema := map[string]*schema.Schema{
 		MetaResourcePath: PropResourcePath("/interface/ethernet"),
 		MetaId:           PropId(Id),
-		MetaSkipFields:   PropSkipFields(
+		MetaSkipFields: PropSkipFields(
 			`"factory_name","driver_rx_byte","driver_rx_packet","driver_tx_byte","driver_tx_packet",` +
 				`"rx_64","rx_65_127","rx_128_255","rx_256_511","rx_512_1023","rx_1024_1518","rx_1519_max",` +
 				`"tx_64","tx_65_127","tx_128_255","tx_256_511","tx_512_1023","tx_1024_1518","tx_1519_max",` +
-				`"tx_rx_64","tx_rx_65_127","tx_rx_128_255","tx_rx_256_511","tx_rx_512_1023","tx_rx_1024_1518","tx_rx_1519_max",` +
+				`"tx_rx_64","tx_rx_65_127","tx_rx_128_255","tx_rx_256_511","tx_rx_512_1023","tx_rx_1024_1518","tx_rx_1024_max",tx_rx_1519_max",` +
 				`"rx_broadcast","rx_bytes","rx_control","rx_drop","rx_fcs_error","rx_fragment","rx_jabber","rx_multicast","rx_packet","rx_pause","rx_too_short","rx_too_long",` +
 				`"tx_broadcast","tx_bytes","tx_control","tx_drop","tx_fcs_error","tx_fragment","tx_jabber","tx_multicast","tx_packet","tx_pause","tx_too_short","tx_too_long",` +
-				`"rx_align_error","rx_carrier_error","rx_code_error","rx_length_error","rx_overflow","rx_unknown_op",` +
+				`"rx_align_error","rx_carrier_error","rx_code_error","rx_error_events","rx_length_error","rx_overflow","rx_unknown_op",` +
 				`"tx_collision","tx_excessive_collision","tx_late_collision","tx_multiple_collision","tx_single_collision","tx_total_collision",` +
-				`"tx_deferred","tx_excessive_deferred","tx_underrun",`,
+				`"tx_deferred","tx_excessive_deferred","tx_unicast","tx_underrun",`,
 		),
 
 		"advertise": {
@@ -94,10 +94,10 @@ func ResourceInterfaceEthernet() *schema.Resource {
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"cable_settings": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: `Changes the cable length setting (only applicable to NS DP83815/6 cards)`,
-			ValidateFunc: validation.StringInSlice([]string{"default", "short", "standard"}, false),
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      `Changes the cable length setting (only applicable to NS DP83815/6 cards)`,
+			ValidateFunc:     validation.StringInSlice([]string{"default", "short", "standard"}, false),
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"combo_mode": {
@@ -134,7 +134,7 @@ func ResourceInterfaceEthernet() *schema.Resource {
 			Description:      `Defines whether the transmission of data appears in two directions simultaneously, only applies when auto-negotiation is disabled.`,
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
-		KeyL2Mtu: 					PropL2MtuRo,
+		KeyL2Mtu:                   PropL2MtuRo,
 		KeyLoopProtect:             PropLoopProtectRw,
 		KeyLoopProtectDisableTime:  PropLoopProtectDisableTimeRw,
 		KeyLoopProtectSendInterval: PropLoopProtectSendIntervalRw,
@@ -171,10 +171,10 @@ func ResourceInterfaceEthernet() *schema.Resource {
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"poe_out": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "PoE settings: (https://wiki.mikrotik.com/wiki/Manual:PoE-Out)",
-			ValidateFunc: validation.StringInSlice([]string{"auto-on", "forced-on", "off"},	false),
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "PoE settings: (https://wiki.mikrotik.com/wiki/Manual:PoE-Out)",
+			ValidateFunc:     validation.StringInSlice([]string{"auto-on", "forced-on", "off"}, false),
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"poe_priority": {


### PR DESCRIPTION
On latest version of Router OS: 7.13.4 The following warnings are pressent for interfaces of type ethernet:

```
│ Warning: Field 'tx_rx_1024_max' not found in the schema
│ 
│   with routeros_interface_ethernet.eths["core-link-2"],
│   on interfaces.tf line 87, in resource "routeros_interface_ethernet" "eths":
│   87: resource "routeros_interface_ethernet" "eths" {
│ 
│ [MikrotikResourceDataToTerraform] The field was lost during the Schema development: ▷ 'tx_rx_1024_max': '2557838' ◁

│ Warning: Field 'tx_unicast' not found in the schema
│ 
│   with routeros_interface_ethernet.eths["core-link-2"],
│   on interfaces.tf line 87, in resource "routeros_interface_ethernet" "eths":
│   87: resource "routeros_interface_ethernet" "eths" {
│ 
│ [MikrotikResourceDataToTerraform] The field was lost during the Schema development: ▷ 'tx_unicast': '3940625' ◁

│ Warning: Field 'rx_error_events' not found in the schema
│ 
│   with routeros_interface_ethernet.eths["core-link-2"],
│   on interfaces.tf line 87, in resource "routeros_interface_ethernet" "eths":
│   87: resource "routeros_interface_ethernet" "eths" {
│ 
│ [MikrotikResourceDataToTerraform] The field was lost during the Schema development: ▷ 'rx_error_events': '0' ◁
│ Warning: Field 'rx_unicast' not found in the schema
│ 
│   with routeros_interface_ethernet.eths["core-link-2"],
│   on interfaces.tf line 87, in resource "routeros_interface_ethernet" "eths":
│   87: resource "routeros_interface_ethernet" "eths" {
│ 
│ [MikrotikResourceDataToTerraform] The field was lost during the Schema development: ▷ 'rx_unicast': '1406391' ◁
│ 
```

As the fields are read only, adding them to skip:
- tx_rx_1024_max
- tx_unicast
- rx_error_events
- rx_unicast