### PR TITLE
fix: release pipeline should be executed on releases only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ on:
 jobs:
 
   release:
-    if: contains(github.event.head_commit.message, 'chore(release)') != true
+    if: contains(github.event.head_commit.message, 'chore(release)') == true
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION

I think the pipeline should be executed on the positve case of the condition.

Fixes: https://github.com/terraform-routeros/terraform-provider-routeros/issues/368