### PR TITLE
feat: Add `routeros_wifi` resource to manage WiFi interfaces

### DIFF
--- a/examples/resources/routeros_wifi/import.sh
+++ b/examples/resources/routeros_wifi/import.sh
@@ -1,0 +1,3 @@
+#The ID can be found via API or the terminal
+#The command for the terminal is -> :put [/interface/wifi get [print show-ids]]
+terraform import routeros_wifi.wifi1 '*1'

--- a/examples/resources/routeros_wifi/resource.tf
+++ b/examples/resources/routeros_wifi/resource.tf
@@ -1,0 +1,6 @@
+resource "routeros_wifi" "wifi1" {
+  configuration = {
+    manager = "capsman"
+  }
+  name = "wifi1"
+}

--- a/routeros/provider.go
+++ b/routeros/provider.go
@@ -241,6 +241,7 @@ func Provider() *schema.Provider {
 			"routeros_user_manager_user_profile":       ResourceUserManagerUserProfile(),
 
 			// WiFi
+			"routeros_wifi":               ResourceWifi(),
 			"routeros_wifi_aaa":           ResourceWifiAaa(),
 			"routeros_wifi_access_list":   ResourceWifiAccessList(),
 			"routeros_wifi_cap":           ResourceWifiCap(),

--- a/routeros/provider_schema_helpers.go
+++ b/routeros/provider_schema_helpers.go
@@ -334,6 +334,14 @@ var (
 		Description: "Layer2 Maximum transmission unit. " +
 			"[See](https://wiki.mikrotik.com/wiki/Maximum_Transmission_Unit_on_RouterBoards).",
 	}
+	PropL2MtuRw = &schema.Schema{
+		Type:     schema.TypeInt,
+		Optional: true,
+		Description: "Layer2 Maximum transmission unit. " +
+			"[See](https://wiki.mikrotik.com/wiki/Maximum_Transmission_Unit_on_RouterBoards).",
+		ValidateFunc:     validation.IntBetween(1, 65535),
+		DiffSuppressFunc: AlwaysPresentNotUserProvided,
+	}
 	PropLocalAddressRw = &schema.Schema{
 		Type:         schema.TypeString,
 		Optional:     true,

--- a/routeros/resource_interface_ethernet.go
+++ b/routeros/resource_interface_ethernet.go
@@ -134,12 +134,7 @@ func ResourceInterfaceEthernet() *schema.Resource {
 			Description:      `Defines whether the transmission of data appears in two directions simultaneously, only applies when auto-negotiation is disabled.`,
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
-		KeyL2Mtu: {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Description: "Layer2 Maximum transmission unit. " +
-				"[See](https://wiki.mikrotik.com/wiki/Maximum_Transmission_Unit_on_RouterBoards).",
-		},
+		KeyL2Mtu:                   PropL2MtuRw,
 		KeyLoopProtect:             PropLoopProtectRw,
 		KeyLoopProtectDisableTime:  PropLoopProtectDisableTimeRw,
 		KeyLoopProtectSendInterval: PropLoopProtectSendIntervalRw,

--- a/routeros/resource_wifi.go
+++ b/routeros/resource_wifi.go
@@ -1,0 +1,163 @@
+package routeros
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+/*
+{
+    ".about": "mode: AP, SSID: wlan, channel: 2462/n",
+    ".id": "*1",
+    "arp": "enabled",
+    "arp-timeout": "auto",
+    "bound": "true",
+    "configuration": "cfg1",
+    "configuration.manager": "capsman",
+    "configuration.mode": "ap",
+    "default-name": "wifi1",
+    "disabled": "false",
+    "inactive": "false",
+    "l2mtu": "1560",
+    "mac-address": "00:00:00:00:00:00",
+    "master": "true",
+    "name": "wifi1",
+    "radio-mac": "00:00:00:00:00:00",
+    "running": "true",
+    "security.connect-priority": "0"
+}
+*/
+
+// https://help.mikrotik.com/docs/display/ROS/WiFi#WiFi-Miscellaneousproperties
+// https://help.mikrotik.com/docs/display/ROS/WiFi#WiFi-Read-onlyproperties
+func ResourceWifi() *schema.Resource {
+	resSchema := map[string]*schema.Schema{
+		MetaResourcePath: PropResourcePath("/interface/wifi"),
+		MetaId:           PropId(Id),
+		MetaTransformSet: PropTransformSet(`"aaa": "aaa.config", "channel": "channel.config", "configuration": "configuration.config",
+		"datapath": "datapath.config", "interworking": "interworking.config", "security": "security.config", "steering": "steering.config"`),
+
+		"aaa": {
+			Type:             schema.TypeMap,
+			Optional:         true,
+			Elem:             &schema.Schema{Type: schema.TypeString},
+			Description:      "AAA inline settings.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
+		KeyArp:        PropArpRw,
+		KeyArpTimeout: PropArpTimeoutRw,
+		"bound": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "A flag whether the interface is currently available for the WiFi manager.",
+		},
+		"channel": {
+			Type:             schema.TypeMap,
+			Optional:         true,
+			Elem:             &schema.Schema{Type: schema.TypeString},
+			Description:      "Channel inline settings.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
+		"configuration": {
+			Type:             schema.TypeMap,
+			Optional:         true,
+			Elem:             &schema.Schema{Type: schema.TypeString},
+			Description:      "Configuration inline settings.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
+		"datapath": {
+			Type:             schema.TypeMap,
+			Optional:         true,
+			Elem:             &schema.Schema{Type: schema.TypeString},
+			Description:      "Datapath inline settings.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
+		"default_name": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The interface's default name.",
+		},
+		KeyDisabled: PropDisabledRw,
+		"disable_running_check": {
+			Type:            schema.TypeBool,
+			Optional:        true,
+			Description:     "An option to set the running property to true if it is not disabled.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
+		"inactive": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "A flag whether the interface is currently inactive.",
+		},
+		"interworking": {
+			Type:             schema.TypeMap,
+			Optional:         true,
+			Elem:             &schema.Schema{Type: schema.TypeString},
+			Description:      "Interworking inline settings.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
+		KeyL2Mtu: PropL2MtuRw,
+		"mac_address": {
+			Type:             schema.TypeString,
+			Description:      "MAC address (BSSID) to use for the interface.",
+			Optional:         true,
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
+		"master": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "A flag whether the interface is not a virtual one.",
+		},
+		"master_interface": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The corresponding master interface of the virtual one.",
+		},
+		"mtu": {
+			Type:             schema.TypeInt,
+			Optional:         true,
+			Description:      "Layer3 maximum transmission unit",
+			ValidateFunc:     validation.IntBetween(32, 2290),
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
+		KeyName: PropName("Name of the interface."),
+		"radio_mac": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The MAC address of the associated radio.",
+		},
+		"running": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "A flag whether the interface has established a link to another device.",
+		},
+		"security": {
+			Type:             schema.TypeMap,
+			Optional:         true,
+			Elem:             &schema.Schema{Type: schema.TypeString},
+			Description:      "Security inline settings.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
+		"steering": {
+			Type:             schema.TypeMap,
+			Optional:         true,
+			Elem:             &schema.Schema{Type: schema.TypeString},
+			Description:      "Steering inline settings.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
+	}
+
+	return &schema.Resource{
+		Description:   `*<span style="color:red">This resource requires a minimum version of RouterOS 7.13.</span>*`,
+		CreateContext: DefaultCreate(resSchema),
+		ReadContext:   DefaultRead(resSchema),
+		UpdateContext: DefaultUpdate(resSchema),
+		DeleteContext: DefaultDelete(resSchema),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: resSchema,
+	}
+}

--- a/routeros/resource_wifi_configuration.go
+++ b/routeros/resource_wifi_configuration.go
@@ -42,10 +42,11 @@ func ResourceWifiConfiguration() *schema.Resource {
 		"interworking": "interworking.config", "security": "security.config", "steering": "steering.config"`),
 
 		"aaa": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Elem: &schema.Schema{Type: schema.TypeString},
-			Description: "AAA inline settings.",
+			Type:             schema.TypeMap,
+			Optional:         true,
+			Elem:             &schema.Schema{Type: schema.TypeString},
+			Description:      "AAA inline settings.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"antenna_gain": {
 			Type:         schema.TypeInt,
@@ -69,10 +70,11 @@ func ResourceWifiConfiguration() *schema.Resource {
 			Description: "Radio chains to use for receiving signals.",
 		},
 		"channel": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Elem:        &schema.Schema{Type: schema.TypeString},
-			Description: "Channel inline settings.",
+			Type:             schema.TypeMap,
+			Optional:         true,
+			Elem:             &schema.Schema{Type: schema.TypeString},
+			Description:      "Channel inline settings.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		KeyComment: PropCommentRw,
 		"country": {
@@ -81,10 +83,11 @@ func ResourceWifiConfiguration() *schema.Resource {
 			Description: "An option determines which regulatory domain restrictions are applied to an interface.",
 		},
 		"datapath": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Elem:        &schema.Schema{Type: schema.TypeString},
-			Description: "Datapath inline settings.",
+			Type:             schema.TypeMap,
+			Optional:         true,
+			Elem:             &schema.Schema{Type: schema.TypeString},
+			Description:      "Datapath inline settings.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		KeyDisabled: PropDisabledRw,
 		"dtim_period": {
@@ -101,10 +104,11 @@ func ResourceWifiConfiguration() *schema.Resource {
 				"improve the security of the wireless network, because SSID is included in other frames sent by the AP.",
 		},
 		"interworking": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Elem:        &schema.Schema{Type: schema.TypeString},
-			Description: "Interworking inline settings.",
+			Type:             schema.TypeMap,
+			Optional:         true,
+			Elem:             &schema.Schema{Type: schema.TypeString},
+			Description:      "Interworking inline settings.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"manager": {
 			Type:         schema.TypeString,
@@ -132,10 +136,11 @@ func ResourceWifiConfiguration() *schema.Resource {
 			ValidateFunc: validation.StringInSlice([]string{"dscp-high-3-bits", "priority"}, false),
 		},
 		"security": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Elem:        &schema.Schema{Type: schema.TypeString},
-			Description: "Security inline settings.",
+			Type:             schema.TypeMap,
+			Optional:         true,
+			Elem:             &schema.Schema{Type: schema.TypeString},
+			Description:      "Security inline settings.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"ssid": {
 			Type:     schema.TypeString,
@@ -143,10 +148,11 @@ func ResourceWifiConfiguration() *schema.Resource {
 			Description: "SSID (service set identifier) is a name broadcast in the beacons that identifies wireless network.",
 		},
 		"steering": {
-			Type:        schema.TypeMap,
-			Optional:    true,
-			Elem:        &schema.Schema{Type: schema.TypeString},
-			Description: "Steering inline settings.",
+			Type:             schema.TypeMap,
+			Optional:         true,
+			Elem:             &schema.Schema{Type: schema.TypeString},
+			Description:      "Steering inline settings.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"tx_chains": {
 			Type:     schema.TypeSet,


### PR DESCRIPTION
The goal of this PR is to add support for managing WiFi interfaces, but that required some additional changes:
- Refactored `AlwaysPresentNotUserProvided` helper to handle map types correctly.
- Moved L2 MTU property into a reusable helper.
- Fixed `routeros_wifi_configuration` to align with the newly introduced `routeros_wifi`.
