### PR TITLE
feat: Resolve warnings due to some missing properties

### DIFF
--- a/routeros/resource_interface_bridge_vlan.go
+++ b/routeros/resource_interface_bridge_vlan.go
@@ -27,6 +27,7 @@ func ResourceInterfaceBridgeVlan() *schema.Resource {
 	resSchema := map[string]*schema.Schema{
 		MetaResourcePath: PropResourcePath("/interface/bridge/vlan"),
 		MetaId:           PropId(Id),
+		MetaSkipFields:   PropSkipFields(`"debug_info"`),
 
 		"bridge": {
 			Type:        schema.TypeString,

--- a/routeros/resource_interface_ethernet.go
+++ b/routeros/resource_interface_ethernet.go
@@ -56,10 +56,10 @@ func ResourceInterfaceEthernet() *schema.Resource {
 			`"factory_name","driver_rx_byte","driver_rx_packet","driver_tx_byte","driver_tx_packet",` +
 				`"rx_64","rx_65_127","rx_128_255","rx_256_511","rx_512_1023","rx_1024_1518","rx_1519_max",` +
 				`"tx_64","tx_65_127","tx_128_255","tx_256_511","tx_512_1023","tx_1024_1518","tx_1519_max",` +
-				`"tx_rx_64","tx_rx_65_127","tx_rx_128_255","tx_rx_256_511","tx_rx_512_1023","tx_rx_1024_1518","tx_rx_1024_max",tx_rx_1519_max",` +
+				`"tx_rx_64","tx_rx_65_127","tx_rx_128_255","tx_rx_256_511","tx_rx_512_1023","tx_rx_1024_1518","tx_rx_1024_max","tx_rx_1519_max",` +
 				`"rx_broadcast","rx_bytes","rx_control","rx_drop","rx_fcs_error","rx_fragment","rx_jabber","rx_multicast","rx_packet","rx_pause","rx_too_short","rx_too_long",` +
 				`"tx_broadcast","tx_bytes","tx_control","tx_drop","tx_fcs_error","tx_fragment","tx_jabber","tx_multicast","tx_packet","tx_pause","tx_too_short","tx_too_long",` +
-				`"rx_align_error","rx_carrier_error","rx_code_error","rx_error_events","rx_length_error","rx_overflow","rx_unicast","rx_unknown_op"` +
+				`"rx_align_error","rx_carrier_error","rx_code_error","rx_error_events","rx_length_error","rx_overflow","rx_unicast","rx_unknown_op",` +
 				`"tx_collision","tx_excessive_collision","tx_late_collision","tx_multiple_collision","tx_single_collision","tx_total_collision",` +
 				`"tx_deferred","tx_excessive_deferred","tx_unicast","tx_underrun"`,
 		),

--- a/routeros/resource_ovpn_server.go
+++ b/routeros/resource_ovpn_server.go
@@ -135,6 +135,13 @@ func ResourceOpenVPNServer() *schema.Resource {
 			Description:  "indicates the protocol to use when connecting with the remote endpoint.",
 			ValidateFunc: validation.StringInSlice([]string{"tcp", "udp"}, false),
 		},
+		"push_routes": {
+			Type:             schema.TypeSet,
+			Optional:         true,
+			Elem:             &schema.Schema{Type: schema.TypeString},
+			Description:      "Push routes to the VPN client (available since RouterOS 7.14).",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
 		"redirect_gateway": {
 			Type:     schema.TypeString,
 			Optional: true,


### PR DESCRIPTION
This PR adds/fixes the following:
- Skip the newly introduced `debug_info` property in the `routeros_interface_bridge_vlan` resource - added in 7.14.
- Add the newly introduced `push_routes` property to the `routeros_ovpn_server` resource - added in 7.14.
- Fix corrupted skipped fields meta property in `routeros_interface_ethernet` - regression from #359.