### PR TITLE
feat: Add ZeroTier support

### DIFF
--- a/examples/resources/routeros_zerotier/import.sh
+++ b/examples/resources/routeros_zerotier/import.sh
@@ -1,0 +1,3 @@
+#The ID can be found via API or the terminal
+#The command for the terminal is -> :put [/zerotier get [print show-ids]]
+terraform import routeros_zerotier.zt1 '*1'

--- a/examples/resources/routeros_zerotier/resource.tf
+++ b/examples/resources/routeros_zerotier/resource.tf
@@ -1,0 +1,8 @@
+resource "zerotier_identity" "identity" {}
+
+resource "routeros_zerotier" "zt1" {
+  comment    = "ZeroTier Central"
+  identity   = zerotier_identity.identity.private_key
+  interfaces = ["all"]
+  name       = "zt1"
+}

--- a/examples/resources/routeros_zerotier_controller/import.sh
+++ b/examples/resources/routeros_zerotier_controller/import.sh
@@ -1,0 +1,3 @@
+#The ID can be found via API or the terminal
+#The command for the terminal is -> :put [/zerotier/controller get [print show-ids]]
+terraform import routeros_zerotier_controller.test '*1'

--- a/examples/resources/routeros_zerotier_controller/resource.tf
+++ b/examples/resources/routeros_zerotier_controller/resource.tf
@@ -1,0 +1,15 @@
+resource "zerotier_identity" "identity" {}
+
+resource "routeros_zerotier" "zt1" {
+  comment    = "ZeroTier Central"
+  identity   = zerotier_identity.identity.private_key
+  interfaces = ["all"]
+  name       = "zt1"
+}
+
+resource "routeros_zerotier_controller" "test" {
+  instance = routeros_zerotier.zt1.name
+  name     = "test"
+  network  = "1234567812345678"
+  private  = true
+}

--- a/examples/resources/routeros_zerotier_interface/import.sh
+++ b/examples/resources/routeros_zerotier_interface/import.sh
@@ -1,0 +1,3 @@
+#The ID can be found via API or the terminal
+#The command for the terminal is -> :put [/zerotier/interface get [print show-ids]]
+terraform import routeros_zerotier_interface.zerotier1 '*1'

--- a/examples/resources/routeros_zerotier_interface/resource.tf
+++ b/examples/resources/routeros_zerotier_interface/resource.tf
@@ -1,0 +1,31 @@
+resource "zerotier_identity" "identity" {}
+
+resource "zerotier_network" "network" {
+  name = "test"
+}
+
+resource "zerotier_member" "member" {
+  authorized              = true
+  member_id               = zerotier_identity.identity.id
+  name                    = "test"
+  network_id              = zerotier_network.network.id
+  hidden                  = false
+  allow_ethernet_bridging = true
+  no_auto_assign_ips      = true
+}
+
+resource "routeros_zerotier" "zt1" {
+  comment    = "ZeroTier Central"
+  identity   = zerotier_identity.identity.private_key
+  interfaces = ["all"]
+  name       = "zt1"
+}
+
+resource "routeros_zerotier_interface" "zerotier1" {
+  allow_default = false
+  allow_global  = false
+  allow_managed = false
+  instance      = routeros_zerotier.zt1.name
+  name          = "zerotier1"
+  network       = zerotier_network.network.id
+}

--- a/routeros/provider.go
+++ b/routeros/provider.go
@@ -259,8 +259,9 @@ func Provider() *schema.Provider {
 			"routeros_wifi_steering":      ResourceWifiSteering(),
 
 			// ZeroTier
-			"routeros_zerotier":           ResourceZerotier(),
-			"routeros_zerotier_interface": ResourceZerotierInterface(),
+			"routeros_zerotier":            ResourceZerotier(),
+			"routeros_zerotier_controller": ResourceZerotierController(),
+			"routeros_zerotier_interface":  ResourceZerotierInterface(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"routeros_firewall":              DatasourceFirewall(),

--- a/routeros/provider.go
+++ b/routeros/provider.go
@@ -257,6 +257,9 @@ func Provider() *schema.Provider {
 			"routeros_wifi_provisioning":  ResourceWifiProvisioning(),
 			"routeros_wifi_security":      ResourceWifiSecurity(),
 			"routeros_wifi_steering":      ResourceWifiSteering(),
+
+			// ZeroTier
+			"routeros_zerotier": ResourceZerotier(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"routeros_firewall":              DatasourceFirewall(),

--- a/routeros/provider.go
+++ b/routeros/provider.go
@@ -259,7 +259,8 @@ func Provider() *schema.Provider {
 			"routeros_wifi_steering":      ResourceWifiSteering(),
 
 			// ZeroTier
-			"routeros_zerotier": ResourceZerotier(),
+			"routeros_zerotier":           ResourceZerotier(),
+			"routeros_zerotier_interface": ResourceZerotierInterface(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"routeros_firewall":              DatasourceFirewall(),

--- a/routeros/resource_zerotier.go
+++ b/routeros/resource_zerotier.go
@@ -1,0 +1,89 @@
+package routeros
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+/*
+{
+    ".id": "*1",
+    "comment": "ZeroTier Central controller - https://my.zerotier.com/",
+    "disabled": "false",
+    "identity": "...",
+    "identity.public": "...",
+    "interfaces": "all",
+    "name": "zt1",
+    "online": "true",
+    "port": "9993",
+    "route-distance": "1",
+    "state": "running"
+}
+*/
+
+// https://help.mikrotik.com/docs/display/ROS/ZeroTier#ZeroTier-Parameters
+func ResourceZerotier() *schema.Resource {
+	resSchema := map[string]*schema.Schema{
+		MetaResourcePath: PropResourcePath("/zerotier"),
+		MetaId:           PropId(Id),
+		MetaTransformSet: PropTransformSet(`"identity.public": "identity_public"`),
+
+		KeyComment: PropCommentRw,
+		KeyDisabled: PropDisabledRw,
+		"identity": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "The 40-bit unique instance address.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
+		"identity_public": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The public identity of the ZeroTier instance.",
+		},
+		"interfaces": {
+			Type:             schema.TypeSet,
+			Optional:         true,
+			Elem:             &schema.Schema{Type: schema.TypeString},
+			Description:      "The interfaces to discover ZeroTier peers by ARP and IP type connections.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
+		KeyName: PropName("Name of the ZeroTier instance."),
+		"online": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "A flag whether the ZeroTier instance is currently online.",
+		},
+		"port": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Default:      9993,
+			Description:  "The port number the instance listens to.",
+			ValidateFunc: validation.IntBetween(1, 65535),
+		},
+		"route_distance": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Default:     1,
+			Description: "The route distance for routes obtained from the planet/moon server.",
+		},
+		"state": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The state of the ZeroTier instance.",
+		},
+	}
+
+	return &schema.Resource{
+		CreateContext: DefaultCreate(resSchema),
+		ReadContext:   DefaultRead(resSchema),
+		UpdateContext: DefaultUpdate(resSchema),
+		DeleteContext: DefaultDelete(resSchema),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: resSchema,
+	}
+}

--- a/routeros/resource_zerotier_controller.go
+++ b/routeros/resource_zerotier_controller.go
@@ -1,0 +1,113 @@
+package routeros
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+/*
+{
+    ".id": "*1",
+    "broadcast": "false",
+    "comment": "Something",
+    "disabled": "false",
+    "inactive": "true",
+    "instance": "zt1",
+    "ip-range": "192.168.88.200-192.168.88.220",
+    "ip6-6plane": "false",
+    "ip6-range": "fd00:feed:feed:beef::-fd00:feed:feed:beef:ffff:ffff:ffff:ffff",
+    "ip6-rfc4193": "false",
+    "mtu": "1598",
+    "multicast-limit": "32",
+    "name": "test",
+    "network": "1234567812345678",
+    "private": "true",
+    "routes": "192.168.88.0/24@192.168.88.1,0.0.0.0/0@192.168.88.1"
+}
+*/
+
+// https://help.mikrotik.com/docs/display/ROS/ZeroTier#ZeroTier-Parameters.1
+func ResourceZerotierController() *schema.Resource {
+	resSchema := map[string]*schema.Schema{
+		MetaResourcePath: PropResourcePath("/zerotier/controller"),
+		MetaId:           PropId(Id),
+
+		"broadcast": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "An option to allow receiving broadcast packets.",
+		},
+		KeyComment:  PropCommentRw,
+		KeyDisabled: PropDisabledRw,
+		"inactive": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "A flag whether the ZeroTier network is inactive.",
+		},
+		"instance": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The ZeroTier instance name.",
+		},
+		"ip_range": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The IP range of the ZeroTier network.",
+		},
+		"ip6_6plane": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "An option to assign every member a `/80` address within a `/40` network with using NDP emulation.",
+		},
+		"ip6_range": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The IPv6 range of the ZeroTier network.",
+		},
+		"ip6_rfc4193": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "An option to assign every member a `/128` address within a `/88` network.",
+		},
+		KeyMtu: PropL2MtuRw,
+		"multicast_limit": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Default:     32,
+			Description: "An option to limit the maximum recipients of a multicast packet.",
+		},
+		KeyName: PropName("Name of the ZeroTier controller."),
+		"network": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The ZeroTier network identifier.",
+		},
+		"private": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "The ZeroTier network access control.",
+		},
+		"routes": {
+			Type:        schema.TypeSet,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Description: "The routes list that will be pushed to the client.",
+		},
+	}
+
+	return &schema.Resource{
+		CreateContext: DefaultCreate(resSchema),
+		ReadContext:   DefaultRead(resSchema),
+		UpdateContext: DefaultUpdate(resSchema),
+		DeleteContext: DefaultDelete(resSchema),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: resSchema,
+	}
+}

--- a/routeros/resource_zerotier_interface.go
+++ b/routeros/resource_zerotier_interface.go
@@ -1,0 +1,115 @@
+package routeros
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+/*
+{
+    ".id": "*1",
+    "allow-default": "false",
+    "allow-global": "false",
+    "allow-managed": "false",
+    "arp-timeout": "auto",
+    "bridge": "true",
+    "dhcp": "false",
+    "disabled": "false",
+    "instance": "zt1",
+    "mac-address": "00:00:00:00:00:00",
+    "mtu": "2800",
+    "name": "zerotier1",
+    "network": "a00000000aa00a00",
+    "network-name": "something",
+    "running": "true",
+    "status": "OK",
+    "type": "PRIVATE"
+}
+*/
+
+// https://help.mikrotik.com/docs/display/ROS/ZeroTier#ZeroTier-Parameters
+func ResourceZerotierInterface() *schema.Resource {
+	resSchema := map[string]*schema.Schema{
+		MetaResourcePath: PropResourcePath("/zerotier/interface"),
+		MetaId:           PropId(Id),
+
+		"allow_default": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "An option to override the default route.",
+		},
+		"allow_global": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "An option to allow overlapping public IP space by the ZeroTier routes. .",
+		},
+		"allow_managed": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "An option to allow assignment of managed IPs.",
+		},
+		KeyArpTimeout: PropArpTimeoutRw,
+		"bridge": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "A flag whether the ZeroTier interface is bridged.",
+		},
+		KeyComment:  PropCommentRw,
+		KeyDisabled: PropDisabledRw,
+		"disable_running_check": {
+			Type:            schema.TypeBool,
+			Optional:        true,
+			Description:     "An option to force the `running` property to true.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
+		"dhcp": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "A flag whether the ZeroTier interface obtained an IP address.",
+		},
+		"instance": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The ZeroTier instance name.",
+		},
+		KeyMacAddress: PropMacAddressRo,
+		KeyMtu:        PropL2MtuRo,
+		KeyName:       PropName("Name of the ZeroTier interface."),
+		"network": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The ZeroTier network identifier.",
+		},
+		"network_name": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The ZeroTier network name.",
+		},
+		KeyRunning: PropRunningRo,
+		"status": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The status of the ZeroTier connection.",
+		},
+		"type": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The ZeroTier network type.",
+		},
+	}
+
+	return &schema.Resource{
+		CreateContext: DefaultCreate(resSchema),
+		ReadContext:   DefaultRead(resSchema),
+		UpdateContext: DefaultUpdate(resSchema),
+		DeleteContext: DefaultDelete(resSchema),
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: resSchema,
+	}
+}


### PR DESCRIPTION
This PR adds [ZeroTier](https://help.mikrotik.com/docs/display/ROS/ZeroTier) support with self-sufficient examples using the [`zerotier/zerotier`](https://registry.terraform.io/providers/zerotier/zerotier/latest) provider.

The following resources have been implemented:
- `routeros_zerotier` to manage ZeroTier instances;
- `routeros_zerotier_interface` to manage ZeroTier interface;
- `routeros_zerotier_controller` to manage ZeroTier controller.