### PR TITLE
feat: Add `http` scheme support for the REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ terraform {
 }
 
 provider "routeros" {
-  hosturl  = "(https|api|apis)://my.router.local[:port]"
+  hosturl  = "(http|https|api|apis)://my.router.local[:port]"
   username = "my_username"
   password = "my_super_secret_password"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ resource "routeros_interface_gre" "gre_hq" {
 ### Required
 
 - `hosturl` (String) URL of the ROS router. Include including the scheme:
+  - `http` new REST API
   - `https` new REST API with TLS/SSL
   - `api` old API without TLS/SSL on port 8728
   - `apis` old API with TLS/SSL 8729

--- a/routeros/mikrotik_client.go
+++ b/routeros/mikrotik_client.go
@@ -86,6 +86,7 @@ func NewClient(ctx context.Context, d *schema.ResourceData) (interface{}, diag.D
 
 	// Parse URL.
 	switch routerUrl.Scheme {
+	case "http":
 	case "https":
 	case "apis":
 		routerUrl.Scheme = ""

--- a/routeros/provider.go
+++ b/routeros/provider.go
@@ -25,7 +25,8 @@ func Provider() *schema.Provider {
 	* API: api[s]://host[:port]
 		* api://router.local
 		* apis://router.local:8729
-	* REST: https://host
+	* REST: http[s]://host
+		* http://router.local
 		* https://router.local
 		* router.local
 		* 127.0.0.1

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -22,6 +22,7 @@ To get started with the provider, you first need to enable the REST API on your 
 ### Required
 
 - `hosturl` (String) URL of the ROS router. Include including the scheme:
+  - `http` new REST API
   - `https` new REST API with TLS/SSL
   - `api` old API without TLS/SSL on port 8728
   - `apis` old API with TLS/SSL 8729


### PR DESCRIPTION
This PR enables the `http` scheme support in the connection settings.