### PR TITLE
fix: properly unset firewall filter rule `protocol` field when removed

### DIFF
--- a/routeros/resource_ip_firewall_filter.go
+++ b/routeros/resource_ip_firewall_filter.go
@@ -16,7 +16,7 @@ func ResourceIPFirewallFilter() *schema.Resource {
 		MetaId:           PropId(Id),
 		MetaSkipFields:   PropSkipFields("bytes", "packets"),
 		MetaSetUnsetFields: PropSetUnsetFields("dst_address_list", "src_address_list", "in_interface_list",
-			"out_interface_list", "in_bridge_port_list", "out_bridge_port_list"),
+			"out_interface_list", "in_bridge_port_list", "out_bridge_port_list", "protocol"),
 
 		"action": {
 			Type:        schema.TypeString,

--- a/routeros/resource_ipv6_firewall_filter.go
+++ b/routeros/resource_ipv6_firewall_filter.go
@@ -13,6 +13,8 @@ func ResourceIPv6FirewallFilter() *schema.Resource {
 		MetaResourcePath: PropResourcePath("/ipv6/firewall/filter"),
 		MetaId:           PropId(Id),
 		MetaSkipFields:   PropSkipFields("bytes", "packets"),
+		MetaSetUnsetFields: PropSetUnsetFields("dst_address_list", "src_address_list", "in_interface_list",
+			"out_interface_list", "in_bridge_port_list", "out_bridge_port_list", "protocol"),
 
 		"action": {
 			Type:        schema.TypeString,


### PR DESCRIPTION
Previously, when you attempted to update a firewall rule with a non-null `protocol` field by removing said field, the serializer would set `protocol` to an empty string instead of completely omitting the value, resulting in API errors and ultimately causing the apply job to fail.

I.e, assuming that you have applied the following:

```terraform
resource "routeros_ip_firewall_filter" "rules" {
  chain    = "input"
  action   = "accept"
  protocol = "tcp"
}
```

and then change it to this:

```terraform
resource "routeros_ip_firewall_filter" "rules" {
  chain    = "input"
  action   = "accept"
  # protocol = "tcp"
}
```

The apply would fail with the following API error:

```
2024-04-26T15:40:51.919+0200 [ERROR] vertex "routeros_ip_firewall_filter.rules" error: PATCH 'https://192.168.88.2
18/rest/ip/firewall/filter/*A' returned response code: 400, message: 'Bad Request', details: 'input does not match
 any value of protocol'
 ```

I also took the liberty of aligning the `MetaSetUnsetFields` field in the ipv6_filter rule with its ipv4 counterpart, as I assumed this to be a basic oversight. But if there is a deeper reason behind this discrepancy then I can of course revert that particular change and just add `MetaSetUnsetFields: PropSetUnsetFields("protocol")`.