### PR TITLE
feat: add ability to sign certificates with scep

### DIFF
--- a/examples/resources/routeros_system_certificate/resource.tf
+++ b/examples/resources/routeros_system_certificate/resource.tf
@@ -39,3 +39,13 @@ resource "routeros_system_certificate" "unsigned_crt" {
   key_size         = "1024"
   subject_alt_name = "DNS:router.lan,DNS:myrouter.lan,IP:192.168.88.1"
 }
+
+resource "routeros_system_certificate" "scep_client" {
+  name        = "SCEP-Client"
+  common_name = "scep-client.crt"
+  key_usage   = ["digital-signature", "key-agreement", "tls-client"]
+
+  sign_via_scep {
+    scep_url = "http://scep.server/scep/test"
+  }
+}

--- a/routeros/mikrotik_client.go
+++ b/routeros/mikrotik_client.go
@@ -31,6 +31,7 @@ const (
 	crudDelete
 	crudPost
 	crudSign
+	crudSignViaScep
 	crudRemove
 	crudRevoke
 	crudMove

--- a/routeros/mikrotik_client_api.go
+++ b/routeros/mikrotik_client_api.go
@@ -20,17 +20,18 @@ type ApiClient struct {
 
 var (
 	apiMethodName = map[crudMethod]string{
-		crudCreate: "/add",
-		crudRead:   "/print",
-		crudUpdate: "/set",
-		crudDelete: "/remove",
-		crudPost:   "/set",
-		crudSign:   "/sign",
-		crudRemove: "/remove",
-		crudRevoke: "/issued-revoke",
-		crudMove:   "/move",
-		crudStart:  "/start",
-		crudStop:   "/stop",
+		crudCreate:      "/add",
+		crudRead:        "/print",
+		crudUpdate:      "/set",
+		crudDelete:      "/remove",
+		crudPost:        "/set",
+		crudSign:        "/sign",
+		crudSignViaScep: "/add-scep",
+		crudRemove:      "/remove",
+		crudRevoke:      "/issued-revoke",
+		crudMove:        "/move",
+		crudStart:       "/start",
+		crudStop:        "/stop",
 	}
 )
 

--- a/routeros/mikrotik_client_rest.go
+++ b/routeros/mikrotik_client_rest.go
@@ -27,17 +27,18 @@ type errorResponse struct {
 
 var (
 	restMethodName = map[crudMethod]string{
-		crudCreate: "PUT",
-		crudRead:   "GET",
-		crudUpdate: "PATCH",
-		crudDelete: "DELETE",
-		crudPost:   "POST",
-		crudSign:   "POST",
-		crudRemove: "POST",
-		crudRevoke: "POST",
-		crudMove:   "POST",
-		crudStart:  "POST",
-		crudStop:   "POST",
+		crudCreate:      "PUT",
+		crudRead:        "GET",
+		crudUpdate:      "PATCH",
+		crudDelete:      "DELETE",
+		crudPost:        "POST",
+		crudSign:        "POST",
+		crudSignViaScep: "POST",
+		crudRemove:      "POST",
+		crudRevoke:      "POST",
+		crudMove:        "POST",
+		crudStart:       "POST",
+		crudStop:        "POST",
 	}
 )
 

--- a/routeros/resource_system_certificate.go
+++ b/routeros/resource_system_certificate.go
@@ -63,6 +63,12 @@ func ResourceSystemCertificate() *schema.Resource {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
+		"challenge_password": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Sensitive:   true,
+			Description: "A challenge password for scep client.",
+		},
 		"common_name": {
 			Type:        schema.TypeString,
 			Required:    true,

--- a/routeros/resource_system_certificate.go
+++ b/routeros/resource_system_certificate.go
@@ -229,13 +229,13 @@ func ResourceSystemCertificate() *schema.Resource {
 					"ca": {
 						Type:        schema.TypeString,
 						Optional:    true,
-						Computed:    true,
+						ForceNew:    true,
 						Description: "Which CA to use if signing issued certificates.",
 					},
 					"ca_crl_host": {
 						Type:        schema.TypeString,
 						Optional:    true,
-						Computed:    true,
+						ForceNew:    true,
 						Description: "CRL host if issuing CA certificate.",
 					},
 					// "ca_on_smart_card": {
@@ -262,6 +262,7 @@ func ResourceSystemCertificate() *schema.Resource {
 					"scep_url": {
 						Type:         schema.TypeString,
 						Required:     true,
+						ForceNew:     true,
 						ValidateFunc: validation.IsURLWithScheme([]string{"http"}),
 						Description:  "HTTP URL to the SCEP server.",
 					},
@@ -269,22 +270,26 @@ func ResourceSystemCertificate() *schema.Resource {
 						Type:        schema.TypeString,
 						Optional:    true,
 						Sensitive:   true,
+						ForceNew:    true,
 						Description: "A challenge password.",
 					},
 					"ca_identity": {
 						Type:        schema.TypeString,
 						Optional:    true,
+						ForceNew:    true,
 						Description: "SCEP CA identity.",
 					},
 					"on_smart_card": {
 						Type:        schema.TypeBool,
 						Optional:    true,
+						ForceNew:    true,
 						Description: "Whether to store a private key on smart card if hardware supports it.",
 					},
 					"refresh": {
 						Type:        schema.TypeBool,
 						Optional:    true,
 						Default:     true,
+						ForceNew:    true,
 						Description: "Check certificate expiration and refresh it if expired.",
 					},
 				},

--- a/routeros/resource_system_certificate_test.go
+++ b/routeros/resource_system_certificate_test.go
@@ -27,6 +27,7 @@ func TestAccSystemCertificatesTest_basic(t *testing.T) {
 							resource.TestCheckResourceAttr("routeros_system_certificate.scep_client", "scep_url", "http://scep.server/scep/test"),
 							resource.TestCheckResourceAttrPair("routeros_system_certificate.scep_client", "scep_url", "routeros_system_certificate.scep_client", "sign_via_scep.0.scep_url"),
 							resource.TestCheckResourceAttrSet("routeros_system_certificate.scep_client", "status"),
+							resource.TestCheckResourceAttrPair("routeros_system_certificate.scep_client", "challenge_password", "routeros_system_certificate.scep_client", "sign_via_scep.0.challenge_password"),
 						),
 					},
 				},
@@ -82,7 +83,8 @@ resource "routeros_system_certificate" "scep_client" {
   key_usage   = ["digital-signature", "key-agreement", "tls-client"]
 
   sign_via_scep {
-    scep_url = "http://scep.server/scep/test"
+    scep_url           = "http://scep.server/scep/test"
+    challenge_password = "12345"
   }
 }
 `

--- a/routeros/resource_system_certificate_test.go
+++ b/routeros/resource_system_certificate_test.go
@@ -24,6 +24,9 @@ func TestAccSystemCertificatesTest_basic(t *testing.T) {
 						Check: resource.ComposeTestCheckFunc(
 							testResourcePrimaryInstanceId(testSystemCertificatesAddress),
 							resource.TestCheckResourceAttr(testSystemCertificatesAddress, "name", "Test-Root-CA"),
+							resource.TestCheckResourceAttr("routeros_system_certificate.scep_client", "scep_url", "http://scep.server/scep/test"),
+							resource.TestCheckResourceAttrPair("routeros_system_certificate.scep_client", "scep_url", "routeros_system_certificate.scep_client", "sign_via_scep.0.scep_url"),
+							resource.TestCheckResourceAttrSet("routeros_system_certificate.scep_client", "status"),
 						),
 					},
 				},
@@ -71,6 +74,16 @@ resource "routeros_system_certificate" "unsigned_crt" {
 	common_name      = "unsigned.crt"
 	key_size         = "1024"
 	subject_alt_name = "DNS:router.lan,DNS:myrouter.lan,IP:192.168.88.1"
+}
+
+resource "routeros_system_certificate" "scep_client" {
+  name        = "SCEP-Client"
+  common_name = "scep-client.crt"
+  key_usage   = ["digital-signature", "key-agreement", "tls-client"]
+
+  sign_via_scep {
+    scep_url = "http://scep.server/scep/test"
+  }
 }
 `
 }

--- a/routeros/resource_system_certificate_test.go
+++ b/routeros/resource_system_certificate_test.go
@@ -11,6 +11,8 @@ const testSystemCertificatesAddress = "routeros_system_certificate.root_ca"
 func TestAccSystemCertificatesTest_basic(t *testing.T) {
 	for _, name := range testNames {
 		t.Run(name, func(t *testing.T) {
+			var rootCa, caCrt, serverCrt, clientCrt, scepClient, unsignedCrt MikrotikItem
+
 			resource.Test(t, resource.TestCase{
 				PreCheck: func() {
 					testAccPreCheck(t)
@@ -23,11 +25,94 @@ func TestAccSystemCertificatesTest_basic(t *testing.T) {
 						Config: testAccSystemCertificatesConfig(),
 						Check: resource.ComposeTestCheckFunc(
 							testResourcePrimaryInstanceId(testSystemCertificatesAddress),
+							// root_ca
+							testCheckResourceExists(testSystemCertificatesAddress, "/certificate", &rootCa),
+							testCheckMikrotikItemAttr(testSystemCertificatesAddress, &rootCa, "name", "Test-Root-CA"),
+							testCheckMikrotikItemAttrSet(testSystemCertificatesAddress, &rootCa, "fingerprint"),
 							resource.TestCheckResourceAttr(testSystemCertificatesAddress, "name", "Test-Root-CA"),
+							resource.TestCheckResourceAttrSet(testSystemCertificatesAddress, "fingerprint"),
+							// ca_crt
+							testCheckResourceExists("routeros_system_certificate.ca_crt", "/certificate", &caCrt),
+							testCheckMikrotikItemAttr("routeros_system_certificate.ca_crt", &caCrt, "name", "CA-Certificate"),
+							resource.TestCheckResourceAttr("routeros_system_certificate.ca_crt", "name", "CA-Certificate"),
+							// server_crt
+							testCheckResourceExists("routeros_system_certificate.server_crt", "/certificate", &serverCrt),
+							testCheckMikrotikItemAttr("routeros_system_certificate.server_crt", &serverCrt, "name", "Server-Certificate"),
+							testCheckMikrotikItemAttr("routeros_system_certificate.server_crt", &serverCrt, "ca", "Test-Root-CA"),
+							testCheckMikrotikItemAttrSet("routeros_system_certificate.server_crt", &serverCrt, "fingerprint"),
+							resource.TestCheckResourceAttr("routeros_system_certificate.server_crt", "name", "Server-Certificate"),
+							resource.TestCheckResourceAttr("routeros_system_certificate.server_crt", "ca", "Test-Root-CA"),
+							resource.TestCheckResourceAttrSet("routeros_system_certificate.server_crt", "fingerprint"),
+							// client_crt
+							testCheckResourceExists("routeros_system_certificate.client_crt", "/certificate", &clientCrt),
+							testCheckMikrotikItemAttr("routeros_system_certificate.client_crt", &clientCrt, "name", "Client-Certificate"),
+							resource.TestCheckResourceAttr("routeros_system_certificate.client_crt", "name", "Client-Certificate"),
+							// unsigned_crt
+							testCheckResourceExists("routeros_system_certificate.unsigned_crt", "/certificate", &unsignedCrt),
+							testCheckMikrotikItemAttr("routeros_system_certificate.unsigned_crt", &unsignedCrt, "name", "Unsigned-Certificate"),
+							testCheckNoMikrotikItemAttr("routeros_system_certificate.unsigned_crt", &unsignedCrt, "ca"),
+							testCheckNoMikrotikItemAttr("routeros_system_certificate.unsigned_crt", &unsignedCrt, "fingerprint"),
+							resource.TestCheckResourceAttr("routeros_system_certificate.unsigned_crt", "name", "Unsigned-Certificate"),
+							resource.TestCheckNoResourceAttr("routeros_system_certificate.unsigned_crt", "ca"),
+							resource.TestCheckNoResourceAttr("routeros_system_certificate.unsigned_crt", "fingerprint"),
+							// scep_client
+							testCheckResourceExists("routeros_system_certificate.scep_client", "/certificate", &scepClient),
+							testCheckMikrotikItemAttr("routeros_system_certificate.scep_client", &scepClient, "name", "SCEP-Client"),
+							testCheckMikrotikItemAttr("routeros_system_certificate.scep_client", &scepClient, "common-name", "scep-client.crt"),
+							testCheckMikrotikItemAttr("routeros_system_certificate.scep_client", &scepClient, "key-usage", "digital-signature,key-agreement,tls-client"),
+							testCheckMikrotikItemAttr("routeros_system_certificate.scep_client", &scepClient, "scep-url", "http://scep.server/scep/test"),
+							testCheckMikrotikItemAttr("routeros_system_certificate.scep_client", &scepClient, "challenge-password", "12345"),
+							testCheckMikrotikItemAttrSet("routeros_system_certificate.scep_client", &scepClient, "status"),
+							resource.TestCheckResourceAttr("routeros_system_certificate.scep_client", "name", "SCEP-Client"),
+							resource.TestCheckResourceAttr("routeros_system_certificate.scep_client", "common_name", "scep-client.crt"),
+							resource.TestCheckResourceAttr("routeros_system_certificate.scep_client", "key_usage.#", "3"),
+							resource.TestCheckResourceAttr("routeros_system_certificate.scep_client", "key_usage.0", "digital-signature"),
+							resource.TestCheckResourceAttr("routeros_system_certificate.scep_client", "key_usage.1", "key-agreement"),
+							resource.TestCheckResourceAttr("routeros_system_certificate.scep_client", "key_usage.2", "tls-client"),
 							resource.TestCheckResourceAttr("routeros_system_certificate.scep_client", "scep_url", "http://scep.server/scep/test"),
-							resource.TestCheckResourceAttrPair("routeros_system_certificate.scep_client", "scep_url", "routeros_system_certificate.scep_client", "sign_via_scep.0.scep_url"),
+							resource.TestCheckResourceAttr("routeros_system_certificate.scep_client", "challenge_password", "12345"),
 							resource.TestCheckResourceAttrSet("routeros_system_certificate.scep_client", "status"),
+							resource.TestCheckResourceAttrPair("routeros_system_certificate.scep_client", "scep_url", "routeros_system_certificate.scep_client", "sign_via_scep.0.scep_url"),
 							resource.TestCheckResourceAttrPair("routeros_system_certificate.scep_client", "challenge_password", "routeros_system_certificate.scep_client", "sign_via_scep.0.challenge_password"),
+						),
+					},
+					{
+						Config: testAccSystemCertificatesConfigUpdated(),
+						Check: resource.ComposeAggregateTestCheckFunc(
+							// root_ca
+							testCheckResourceExists(testSystemCertificatesAddress, "/certificate", &rootCa),
+							testCheckMikrotikItemAttr(testSystemCertificatesAddress, &rootCa, "name", "Test-Root-CA"),
+							// ca_crt (added ca_crl_host)
+							testCheckResourceExists("routeros_system_certificate.ca_crt", "/certificate", &caCrt),
+							testCheckMikrotikItemAttr("routeros_system_certificate.ca_crt", &caCrt, "name", "CA-Certificate"),
+							testCheckMikrotikItemAttr("routeros_system_certificate.ca_crt", &caCrt, "ca-crl-host", "10.0.0.1"),
+							resource.TestCheckResourceAttr("routeros_system_certificate.ca_crt", "name", "CA-Certificate"),
+							resource.TestCheckResourceAttr("routeros_system_certificate.ca_crt", "ca_crl_host", "10.0.0.1"),
+							// server_crt (changed name)
+							testCheckResourceExists("routeros_system_certificate.server_crt", "/certificate", &serverCrt),
+							testCheckMikrotikItemAttr("routeros_system_certificate.server_crt", &serverCrt, "name", "Server-Certificate-New"),
+							testCheckMikrotikItemAttr("routeros_system_certificate.server_crt", &serverCrt, "ca", "Test-Root-CA"),
+							resource.TestCheckResourceAttr("routeros_system_certificate.server_crt", "name", "Server-Certificate-New"),
+							resource.TestCheckResourceAttr("routeros_system_certificate.server_crt", "ca", "Test-Root-CA"),
+							// client_crt (added country, renamed to avoid 'name exists' error)
+							testCheckResourceExists("routeros_system_certificate.client_crt", "/certificate", &clientCrt),
+							testCheckMikrotikItemAttr("routeros_system_certificate.client_crt", &clientCrt, "name", "Client-Certificate-New"),
+							testCheckMikrotikItemAttr("routeros_system_certificate.client_crt", &clientCrt, "country", "US"),
+							resource.TestCheckResourceAttr("routeros_system_certificate.client_crt", "name", "Client-Certificate-New"),
+							resource.TestCheckResourceAttr("routeros_system_certificate.client_crt", "country", "US"),
+							// unsigned_crt (certificate requested to be signed)
+							testCheckResourceExists("routeros_system_certificate.unsigned_crt", "/certificate", &unsignedCrt),
+							testCheckMikrotikItemAttr("routeros_system_certificate.unsigned_crt", &unsignedCrt, "name", "Unsigned-Certificate"),
+							testCheckMikrotikItemAttr("routeros_system_certificate.unsigned_crt", &unsignedCrt, "ca", "Test-Root-CA"),
+							testCheckMikrotikItemAttrSet("routeros_system_certificate.unsigned_crt", &unsignedCrt, "fingerprint"),
+							resource.TestCheckResourceAttr("routeros_system_certificate.unsigned_crt", "name", "Unsigned-Certificate"),
+							resource.TestCheckResourceAttr("routeros_system_certificate.unsigned_crt", "ca", "Test-Root-CA"),
+							resource.TestCheckResourceAttrSet("routeros_system_certificate.unsigned_crt", "fingerprint"),
+							// scep_client (changed scep_url)
+							testCheckResourceExists("routeros_system_certificate.scep_client", "/certificate", &scepClient),
+							testCheckMikrotikItemAttr("routeros_system_certificate.scep_client", &scepClient, "name", "SCEP-Client"),
+							testCheckMikrotikItemAttr("routeros_system_certificate.scep_client", &scepClient, "common-name", "scep-client.crt"),
+							testCheckMikrotikItemAttr("routeros_system_certificate.scep_client", &scepClient, "scep-url", "http://scep.server/scep/test_updated"),
 						),
 					},
 				},
@@ -48,6 +133,14 @@ resource "routeros_system_certificate" "root_ca" {
 	sign {
 	}
 }	  
+
+resource "routeros_system_certificate" "ca_crt" {
+	name        = "CA-Certificate"
+	common_name = "ca.crt"
+	key_usage   = ["key-cert-sign", "crl-sign"]
+	sign {
+	}
+}
 
 resource "routeros_system_certificate" "server_crt" {
 	name        = "Server-Certificate"
@@ -84,6 +177,77 @@ resource "routeros_system_certificate" "scep_client" {
 
   sign_via_scep {
     scep_url           = "http://scep.server/scep/test"
+    challenge_password = "12345"
+  }
+}
+`
+}
+
+func testAccSystemCertificatesConfigUpdated() string {
+	return providerConfig + `
+
+resource "routeros_system_certificate" "root_ca" {
+  name        = "Test-Root-CA"
+  common_name = "RootCA"
+  key_usage   = ["key-cert-sign", "crl-sign"]
+  trusted     = true
+  sign {
+  }
+}
+
+# Added ca_crl_host
+resource "routeros_system_certificate" "ca_crt" {
+  name        = "CA-Certificate"
+  common_name = "ca.crt"
+  key_usage   = ["key-cert-sign", "crl-sign"]
+  sign {
+    ca_crl_host = "10.0.0.1"
+  }
+}
+
+# Changed name
+resource "routeros_system_certificate" "server_crt" {
+  name        = "Server-Certificate-New"
+  common_name = "server.crt"
+  // KUs: igitalSignature, keyEncipherment or keyAgreement
+  key_usage   = ["digital-signature", "key-encipherment", "tls-server"]
+  sign {
+    ca = routeros_system_certificate.root_ca.name
+  }
+}
+
+# Added country, have to change a name
+resource "routeros_system_certificate" "client_crt" {
+  name        = "Client-Certificate-New"
+  common_name = "client.crt"
+  country     = "US"
+  key_size    = "prime256v1"
+  // KUs: digitalSignature and/or keyAgreement
+  key_usage   = ["digital-signature", "key-agreement", "tls-client"]
+  sign {
+    ca = routeros_system_certificate.root_ca.name
+  }
+}
+
+# Sign unsigned certificate
+resource "routeros_system_certificate" "unsigned_crt" {
+  name             = "Unsigned-Certificate"
+  common_name      = "unsigned.crt"
+  key_size         = "1024"
+  subject_alt_name = "DNS:router.lan,DNS:myrouter.lan,IP:192.168.88.1"
+  sign {
+    ca = routeros_system_certificate.root_ca.name
+  }
+}
+
+# Changed scep_url
+resource "routeros_system_certificate" "scep_client" {
+  name        = "SCEP-Client"
+  common_name = "scep-client.crt"
+  key_usage   = ["digital-signature", "key-agreement", "tls-client"]
+
+  sign_via_scep {
+    scep_url           = "http://scep.server/scep/test_updated"
     challenge_password = "12345"
   }
 }

--- a/routeros/resource_testing_helper.go
+++ b/routeros/resource_testing_helper.go
@@ -20,3 +20,58 @@ func testResourcePrimaryInstanceId(name string) resource.TestCheckFunc {
 		return nil
 	}
 }
+
+// testCheckMikrotikItemAttr ensures that an attribute in MikrotikItem parameters
+// with the given key equals a specific value
+func testCheckMikrotikItemAttr(name string, params *MikrotikItem, key string, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if params == nil {
+			return fmt.Errorf("%s: mikrotik params is nil", name)
+		}
+
+		v, ok := (*params)[key]
+		if !ok {
+			return fmt.Errorf("%s: attribute '%s' not found", name, key)
+		}
+
+		if v != value {
+			return fmt.Errorf("%s: attribute '%s' expected %s, got %s", name, key, value, v)
+		}
+
+		return nil
+	}
+}
+
+// testCheckMikrotikItemAttrSet ensures any value exists in MikrotikItem parameters
+// for the given key
+func testCheckMikrotikItemAttrSet(name string, params *MikrotikItem, key string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if params == nil {
+			return fmt.Errorf("%s: mikrotik params is nil", name)
+		}
+
+		_, ok := (*params)[key]
+		if !ok {
+			return fmt.Errorf("%s: attribute '%s' expected to be set", name, key)
+		}
+
+		return nil
+	}
+}
+
+// testCheckNoMikrotikItemAttr ensures no value exists in MikrotikItem parameters
+// for the given key
+func testCheckNoMikrotikItemAttr(name string, params *MikrotikItem, key string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if params == nil {
+			return fmt.Errorf("%s: mikrotik params is nil", name)
+		}
+
+		_, ok := (*params)[key]
+		if ok {
+			return fmt.Errorf("%s: attribute '%s' found when not expected", name, key)
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
* add ability to sign certificates with scep (`add-scep` command)
* add missing computed `challenge_password` parameter (present only with scep client)
* add a couple of tests for resource updating, resource attributes are checked from the actual API
* `ForceNew` is not enough on `sign` set. It need to be set on all elements or recreation won't work

There are still some quirks I found:
1. If for the following resources:
```tf
resource "routeros_system_certificate" "root_ca" {
  name        = "Test-Root-CA"
  common_name = "RootCA"
  key_usage   = ["key-cert-sign", "crl-sign"]
  trusted     = true
  sign {
  }
}

resource "routeros_system_certificate" "server_crt" {
  name        = "Server-Certificate"
  common_name = "server.crt"
  key_usage = ["digital-signature", "key-encipherment", "tls-server"]
  sign {
    ca = routeros_system_certificate.root_ca.name
  }
}
```
user would change something in a CA (but not the name):
```tf
resource "routeros_system_certificate" "root_ca" {
  name        = "Test-Root-CA"
  common_name = "RootCA"
  key_usage   = ["key-cert-sign", "crl-sign"]
  trusted     = true
  sign {
    ca_crl_host = "10.1.1.1"
  }
}

resource "routeros_system_certificate" "server_crt" {
  name        = "Server-Certificate"
  common_name = "server.crt"
  // KUs: igitalSignature, keyEncipherment or keyAgreement
  key_usage = ["digital-signature", "key-encipherment", "tls-server"]
  sign {
    ca = routeros_system_certificate.root_ca.name
  }
}
```
then there are errors that resource not found. It's because RouterOS removes all dependent certificates with a CA and the provider can't handle it for now.

2. An ability to remove certificates was added to RouterOS 7.12 (https://mikrotik.com/download/changelogs#c-stable-v7_12: `certificate - allow to remove issued certificates when CRL is not used`), but when CA certificate doen't have crl set. I didn't find a helper to check RouterOS version in the provider. But maybe it can be implemented simpler: just try to delete certificate, and in case there is an error, that certificate can only be revoked, then revoke it. It can be useful for changing certificate attributes without changing the name (otherwise there is a name conflict).