### PR TITLE
feat: add comment to routeros_wifi resource

### DIFF
--- a/docs/resources/wifi.md
+++ b/docs/resources/wifi.md
@@ -29,6 +29,7 @@ resource "routeros_wifi" "wifi1" {
 		* reply-only - the interface will only reply to requests originated from matching IP address/MAC address combinations which are entered as static entries in the ARP table. No dynamic entries will be automatically stored in the ARP table. Therefore for communications to be successful, a valid static entry must already exist.
 - `arp_timeout` (String) ARP timeout is time how long ARP record is kept in ARP table after no packets are received from IP. Value auto equals to the value of arp-timeout in IP/Settings, default is 30s. Can use postfix ms, s, M, h, d for milliseconds, seconds, minutes, hours or days. If no postfix is set then seconds (s) is used.
 - `channel` (Map of String) Channel inline settings.
+- `comment` (String)
 - `configuration` (Map of String) Configuration inline settings.
 - `datapath` (Map of String) Datapath inline settings.
 - `disable_running_check` (Boolean) An option to set the running property to true if it is not disabled.

--- a/routeros/resource_wifi.go
+++ b/routeros/resource_wifi.go
@@ -72,6 +72,7 @@ func ResourceWifi() *schema.Resource {
 			Description:      "Datapath inline settings.",
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
+		KeyComment: PropCommentRw,
 		"default_name": {
 			Type:        schema.TypeString,
 			Computed:    true,


### PR DESCRIPTION
I wanted to manage the wifi interfaces on my router and I noticed that the `comment` property isn't part of the `routeros_wifi` resource schema. So I thought I add it. I've tested it by locally building the binary and running it with terraform, everything seemed to worked correctly.

This is my first contribution to this repository. I haven't found any rules in the repo so I hope this pull request is okay. Let me know if I should change something or add something.