### PR TITLE
fix(snmp-community): Allow a set of `addresses`

### DIFF
--- a/docs/resources/snmp_community.md
+++ b/docs/resources/snmp_community.md
@@ -13,6 +13,7 @@ resource "routeros_snmp_community" "test" {
 	name                    = "private"
 	read_access             = true
 	security                = "private"
+	addresses                = ["192.0.2.0/24", "198.51.100.1", "::" ]
 	write_access            = true
 }
 ```
@@ -22,7 +23,7 @@ resource "routeros_snmp_community" "test" {
 
 ### Optional
 
-- `addresses` (String) Addresses from which connections to SNMP server is allowed.
+- `addresses` (Set of String) Set of IP (v4 or v6) addresses or CIDR networks from which connections to SNMP server are allowed.
 - `authentication_password` (String, Sensitive) Password used to authenticate the connection to the server (SNMPv3).
 - `authentication_protocol` (String) The protocol used for authentication (SNMPv3).
 - `comment` (String)

--- a/routeros/resource_snmp_community.go
+++ b/routeros/resource_snmp_community.go
@@ -30,11 +30,17 @@ func ResourceSNMPCommunity() *schema.Resource {
 		MetaId:           PropId(Id),
 
 		"addresses": {
-			Type:         schema.TypeString,
-			Optional:     true,
-			Default:      "::/0",
-			Description:  "Addresses from which connections to SNMP server is allowed.",
-			ValidateFunc: validation.IsIPAddress,
+			Type:        schema.TypeSet,
+			Optional:    true,
+			Description: "Set of IP (v4 or v6) addresses or CIDR networks from which connections to SNMP server are allowed.",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+				ValidateFunc: validation.Any(
+					validation.IsIPv4Address,
+					validation.IsIPv6Address,
+					validation.IsCIDRNetwork(0, 128),
+				),
+			},
 		},
 		"authentication_password": {
 			Type:        schema.TypeString,

--- a/routeros/resource_snmp_community.go
+++ b/routeros/resource_snmp_community.go
@@ -41,6 +41,7 @@ func ResourceSNMPCommunity() *schema.Resource {
 					validation.IsCIDRNetwork(0, 128),
 				),
 			},
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"authentication_password": {
 			Type:        schema.TypeString,


### PR DESCRIPTION
Fixes #495

This uses the `Any` ability of the Terraform validation library to do either bare ipv4 or ipv6 addresses (which by observing the device essentially become /32 networks) and CIDR networks.

I wasn't sure what to update test-wise, could use help there.