### PR TITLE
feat: Add some new properties introduced in RouterOS 7.15

### DIFF
--- a/routeros/provider_schema_helpers.go
+++ b/routeros/provider_schema_helpers.go
@@ -671,10 +671,6 @@ var (
 	// Prevents the need of hardcode values for default values, as those are harder to track over time/versions of
 	// routeros
 	AlwaysPresentNotUserProvided = func(k, old, new string, d *schema.ResourceData) bool {
-		if old == "" {
-			return false
-		}
-
 		value := d.GetRawConfig()
 
 		// For lists and sets, the key will look like `something.12345` or `something.#`.

--- a/routeros/resource_interface_ethernet.go
+++ b/routeros/resource_interface_ethernet.go
@@ -246,6 +246,12 @@ func ResourceInterfaceEthernet() *schema.Resource {
 				"The default value for SFP/SFP+/SFP28 interfaces is 95, and for QSFP+/QSFP28 interfaces 80 (introduced v7.6).",
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
+		"sfp_ignore_rx_los": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Description: "An option to ignore RX LOS (Loss of Signal) status of the SFP module.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
 		"slave": {
 			Type:        schema.TypeBool,
 			Computed:    true,

--- a/routeros/resource_interface_macvlan.go
+++ b/routeros/resource_interface_macvlan.go
@@ -27,7 +27,6 @@ func ResourceInterfaceMacVlan() *schema.Resource {
 	private - does not allow communication between MACVLAN instances on the same parent interface.
 	bridge - allows communication between MACVLAN instances on the same parent interface.`,
 			ValidateFunc:     validation.StringInSlice([]string{"private", "bridge"}, true),
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		KeyMacAddress: PropMacAddressRw(
 			`Static MAC address of the interface. A randomly generated MAC address will be assigned when not specified.`,

--- a/routeros/resource_ppp_aaa.go
+++ b/routeros/resource_ppp_aaa.go
@@ -25,6 +25,12 @@ func ResourcePppAaa() *schema.Resource {
 			Default:     true,
 			Description: "An option that enables accounting for users.",
 		},
+		"enable_ipv6_accounting": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "An option that enables IPv6 separate accounting.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
 		"interim_update": {
 			Type:             schema.TypeString,
 			Optional:         true,

--- a/routeros/resource_radius.go
+++ b/routeros/resource_radius.go
@@ -67,6 +67,13 @@ func ResourceRadius() *schema.Resource {
 			Optional:    true,
 			Description: "Explicitly stated realm (user domain), so the users do not have to provide proper ISP domain name in the user name.",
 		},
+		"require_message_auth": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "An option whether to require `Message-Authenticator` in received Access-Accept/Challenge/Reject messages.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+			ValidateFunc:     validation.StringInSlice([]string{"no", "yes-for-request-resp"}, false),
+		},
 		"secret": {
 			Type:        schema.TypeString,
 			Optional:    true,

--- a/routeros/resource_user_manager_settings.go
+++ b/routeros/resource_user_manager_settings.go
@@ -42,6 +42,13 @@ func ResourceUserManagerSettings() *schema.Resource {
 			Description: "Certificate for use in EAP TLS-type authentication methods.",
 		},
 		KeyEnabled: PropEnabled("An option whether the User Manager functionality is enabled."),
+		"require_message_auth": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "An option whether to require `Message-Authenticator` in received Access-Accept/Challenge/Reject messages.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+			ValidateFunc:     validation.StringInSlice([]string{"no", "yes-access-request"}, false),
+		},
 		"use_profiles": {
 			Type:        schema.TypeBool,
 			Optional:    true,

--- a/routeros/resource_wifi_cap.go
+++ b/routeros/resource_wifi_cap.go
@@ -11,6 +11,8 @@ import (
     "caps-man-certificate-common-names": "CAPsMAN-0000000",
     "caps-man-names": "router",
     "certificate": "request",
+    "current-caps-man-address": "192.168.88.1",
+    "current-caps-man-identity": "router",
     "discovery-interfaces": "lan",
     "enabled": "no",
     "lock-to-caps-man": "true",
@@ -50,6 +52,16 @@ func ResourceWifiCap() *schema.Resource {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "Certificate to use for authentication.",
+		},
+		"current_caps_man_address": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Currently used CAPsMAN address.",
+		},
+		"current_caps_man_identity": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Currently used CAPsMAN identity.",
 		},
 		"discovery_interfaces": {
 			Type:        schema.TypeSet,

--- a/routeros/resource_wifi_channel.go
+++ b/routeros/resource_wifi_channel.go
@@ -39,6 +39,12 @@ func ResourceWifiChannel() *schema.Resource {
 			Description: "Channel frequency value or range in MHz on which AP or station will operate.",
 		},
 		KeyName: PropName("Name of the channel."),
+		"reselect_interval": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "An option that specifies when the interface should rescan channel availability and select the most appropriate one to use.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
 		"secondary_frequency": {
 			Type:        schema.TypeList,
 			Elem:        &schema.Schema{Type: schema.TypeString},


### PR DESCRIPTION
This PR is mostly about adding newly added properties in the 7.15 release:
- `sfp_ignore_rx_los` to `routeros_interface_ethernet`;
- `enable_ipv6_accounting` to `routeros_ppp_aaa`;
- `require_message_auth` to `routeros_radius`;
- `require_message_auth` to `routeros_user_manager_settings`;
- `reselect_interval` to `routeros_wifi_channel`;
- `current_caps_man_address` to `routeros_wifi_cap`;
- `current_caps_man_identity` to `routeros_wifi_cap`.

On top of that, RouterOS 7.15 started _always_ returning an empty value in `routeros_wifi_configuration` (`/rest/interface/wifi/configuration`):
```
"aaa.password-format": "",
```

Since checking empty old values in the `AlwaysPresentNotUserProvided` helper makes no sense in the first place, we can safely remove this condition. The removal didn't cause any regressions.