### PR TITLE
feat: Update the `routeros_ovpn_server` resource to handle some properties correctly

### DIFF
--- a/examples/resources/routeros_ovpn_server/resource.tf
+++ b/examples/resources/routeros_ovpn_server/resource.tf
@@ -39,7 +39,7 @@ resource "routeros_ppp_secret" "test" {
 resource "routeros_ovpn_server" "server" {
   enabled         = true
   certificate     = routeros_system_certificate.ovpn_server_crt.name
-  auth            = "sha256,sha512"
+  auth            = ["sha256", "sha512"]
   tls_version     = "only-1.2"
   default_profile = routeros_ppp_profile.test.name
 }

--- a/routeros/resource_ovpn_server.go
+++ b/routeros/resource_ovpn_server.go
@@ -47,8 +47,9 @@ func ResourceOpenVPNServer() *schema.Resource {
 		},
 		"certificate": {
 			Type:        schema.TypeString,
-			Required:    true,
+			Optional:    true,
 			Description: "Name of the certificate that the OVPN server will use.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"cipher": {
 			Type:     schema.TypeSet,
@@ -73,6 +74,7 @@ func ResourceOpenVPNServer() *schema.Resource {
 		"enable_tun_ipv6": {
 			Type:        schema.TypeBool,
 			Optional:    true,
+			Default:     false,
 			Description: "Specifies if IPv6 IP tunneling mode should be possible with this OVPN server.",
 		},
 		KeyEnabled: PropEnabled("Defines whether the OVPN server is enabled or not."),
@@ -169,12 +171,14 @@ func ResourceOpenVPNServer() *schema.Resource {
 		"require_client_certificate": {
 			Type:     schema.TypeBool,
 			Optional: true,
+			Default:  false,
 			Description: "If set to yes, then the server checks whether the client's certificate belongs to the " +
 				"same certificate chain.",
 		},
 		"tls_version": {
 			Type:         schema.TypeString,
 			Optional:     true,
+			Default:      "any",
 			Description:  "Specifies which TLS versions to allow.",
 			ValidateFunc: validation.StringInSlice([]string{"any", "only-1.2"}, false),
 		},

--- a/routeros/resource_ovpn_server_test.go
+++ b/routeros/resource_ovpn_server_test.go
@@ -68,8 +68,8 @@ func testAccOpenVPNServerConfig() string {
 	  resource "routeros_ovpn_server" "server" {
 		enabled          = false
 		certificate      = routeros_system_certificate.ovpn_server_crt.name
-		auth             = "sha256,sha512"
-		redirect_gateway = "def1,ipv6"
+		auth             = ["sha256", "sha512"]
+		redirect_gateway = ["def1", "ipv6"]
 		tls_version      = "only-1.2"
 	  }
 	  


### PR DESCRIPTION
- This PR is similar to #501 in migrating `auth`, `cipher`, and `redirect_gateway` to multi-value properties.
- Also, this PR sets correct default values for `require_client_certificate`, `enable_tun_ipv6 `, and `tls_version`.
- Lastly, it also fixes the `certificate` property not to send it when unset.