### PR TITLE
DRAFT change routeros_wifi_provisioning.radio_mac default to empty string

### DIFF
--- a/routeros/resource_wifi_provisioning.go
+++ b/routeros/resource_wifi_provisioning.go
@@ -54,20 +54,20 @@ func ResourceWifiProvisioning() *schema.Resource {
 			Description: "Regular expression to match radios by router identity.",
 		},
 		"master_configuration": {
-			Type:        schema.TypeString,
-			Optional:    true,
+			Type:     schema.TypeString,
+			Optional: true,
 			Description: "If action specifies to create interfaces, then a new master interface with its configuration " +
 				"set to this configuration profile will be created.",
 		},
 		"name_format": {
-			Type:         schema.TypeString,
-			Optional:     true,
-			Description:  "Specify the format of the CAP interface name creation.",
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Specify the format of the CAP interface name creation.",
 		},
 		"radio_mac": {
 			Type:         schema.TypeString,
 			Optional:     true,
-			Default:      "00:00:00:00:00:00",
+			Default:      "",
 			Description:  "MAC address of radio to be matched, empty MAC (00:00:00:00:00:00) means match all MAC addresses.",
 			ValidateFunc: ValidationMacAddress,
 		},
@@ -82,7 +82,7 @@ func ResourceWifiProvisioning() *schema.Resource {
 			Type:     schema.TypeList,
 			Optional: true,
 			Elem: &schema.Schema{
-				Type: schema.TypeString,
+				Type:         schema.TypeString,
 				ValidateFunc: validation.StringInSlice([]string{"2ghz-ax", "2ghz-g", "2ghz-n", "5ghz-a", "5ghz-ac", "5ghz-ax", "5ghz-n"}, false),
 			},
 			Description: "Match CAPs by supported modes.",


### PR DESCRIPTION
Fix/bypass for bug in 7.16 beta4 (and some earlier releases) on mmips64. 

As per https://help.mikrotik.com/docs/pages/viewpage.action?pageId=1409149#APController(CAPsMAN)-RadioProvisioning the `00:00:00:00:00:00` should be equivalent to null or omitted value, but it's actually setting MAC to that value in config and provisioning fails (random guess - it's actually looking for radio with that MAC). Had to implement in code as both validator and default value made it impossible to bypass inside TF (clearing from CLI works, updating in WebFig magically removes the value) :/

Bug was reported to MikroTik support, but due to nature of TF providers this PR is kind of "FYI bug report". 

This is the only way to use CAPsMAN on RouterBoard that does not have Wi-Fi 6 capabilities (e.g. hEX on mmips64) and control CAPs using Wi-Fi 6 (`wifi-qcom`). 
