### PR TITLE
ipv6_neighbor_discovery dns server configuration fix attempt

### DIFF
--- a/routeros/resource_ipv6_neighbor_discovery.go
+++ b/routeros/resource_ipv6_neighbor_discovery.go
@@ -50,11 +50,15 @@ func ResourceIPv6NeighborDiscovery() *schema.Resource {
 			Default:     true,
 		},
 		KeyComment: PropCommentRw,
-		"dns_servers": {
+		"default": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Neighbor discovery entry is the default configuration.",
+		},
+		"dns": {
 			Type:         schema.TypeString,
 			Optional:     true,
-			Description:  "Specify a single IPv6 address or list of addresses that will be provided to hosts for DNS server configuration.",
-			ValidateFunc: validation.IsCIDR,
+			Description:  "Specify a single IPv6 address or comma separated list of addresses that will be provided to hosts for DNS server configuration.",
 		},
 		KeyDisabled: PropDisabledRw,
 		"hop_limit": {
@@ -68,6 +72,11 @@ func ResourceIPv6NeighborDiscovery() *schema.Resource {
 			Required: true,
 			Description: "The interface on which to run neighbor discovery." +
 				"all - run ND on all running interfaces.",
+		},
+		"invalid": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Neighbor discovery configuration is invalid.",
 		},
 		"managed_address_configuration": {
 			Type:        schema.TypeBool,


### PR DESCRIPTION
Greetings,

first thanks for the great work, this provider is quite a wonder

Second, a small PR, that, I think, fix a probable typo

In the `routeros_ipv6_neighbor_discovery` resource, the schema is implemented to use `dns_servers` but it seems this keyword is not present in the RouterOS API (tested on 7.14 and 7.15)

Example below from the `/rest/ipv6/nd` API endpoint
```
[
  {
    ".id": "*1",
    "advertise-dns": "true",
    "advertise-mac-address": "true",
    "default": "true",
    "disabled": "true",
    "dns": "",
    "hop-limit": "unspecified",
    "interface": "all",
    "invalid": "false",
    "managed-address-configuration": "false",
    "mtu": "unspecified",
    "other-configuration": "false",
    "pref64": "",
    "ra-delay": "3s",
    "ra-interval": "3m20s-10m",
    "ra-lifetime": "30m",
    "ra-preference": "medium",
    "reachable-time": "unspecified",
    "retransmit-interval": "unspecified"
  }
]
```

When I attempt to push a Neighbord Discovery configuration I get errors sampled below:

```
│ Error: PUT 'http://host/rest/ipv6/nd' returned response code: 400, message: 'Bad Request', details: 'unknown parameter dns-servers'
│ 
│   with routeros_ipv6_neighbor_discovery.envs["remi"],
│   on envs.tf line 89, in resource "routeros_ipv6_neighbor_discovery" "envs":
│   89: resource routeros_ipv6_neighbor_discovery envs {

```

```
╷
│ Warning: Field 'invalid' not found in the schema
│ 
│   with routeros_ipv6_neighbor_discovery.envs["remi"],
│   on envs.tf line 89, in resource "routeros_ipv6_neighbor_discovery" "envs":
│   89: resource routeros_ipv6_neighbor_discovery envs {
│ 
│ [MikrotikResourceDataToTerraform] The field was lost during the Schema development: ▷ 'invalid': 'false' ◁
╵
╷
│ Warning: Field 'default' not found in the schema
│ 
│   with routeros_ipv6_neighbor_discovery.envs["remi"],
│   on envs.tf line 89, in resource "routeros_ipv6_neighbor_discovery" "envs":
│   89: resource routeros_ipv6_neighbor_discovery envs {
│ 
│ [MikrotikResourceDataToTerraform] The field was lost during the Schema development: ▷ 'default': 'false' ◁
╵
╷
│ Warning: Field 'dns' not found in the schema
│ 
│   with routeros_ipv6_neighbor_discovery.envs["remi"],
│   on envs.tf line 89, in resource "routeros_ipv6_neighbor_discovery" "envs":
│   89: resource routeros_ipv6_neighbor_discovery envs {
│ 
│ [MikrotikResourceDataToTerraform] The field was lost during the Schema development: ▷ 'dns': '' ◁
```

This PR changes the DNS configuration keyword to `dns` (and remove the CIDR validation check as RouterOS awaits a comma separated list of host address(es)) and also add two computed fields for `default` and `invalid`

Let me know if this looks correct for you and I'll add relevant documentation items - unfortunately I'm not familiar enough with terraform provider to add proper testing, on that one I may need guidance