### PR TITLE
fix(ospf_interface_template): RouterOS 7.x & OSPF Interface Template Auth Key

### DIFF
--- a/routeros/resource_routing_ospf_interface_template.go
+++ b/routeros/resource_routing_ospf_interface_template.go
@@ -56,10 +56,18 @@ func ResourceRoutingOspfInterfaceTemplate() *schema.Resource {
 			ValidateFunc: validation.IntBetween(0, 255),
 		},
 		"authentication_key": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Sensitive:   true,
-			Description: "The authentication key to be used, should match on all the neighbors of the network segment.",
+			Type:      schema.TypeString,
+			Optional:  true,
+			Sensitive: true,
+			Description: "The authentication key to be used, should match on all the neighbors of the network segment " +
+				"(for versions before RouterOS 7.x).",
+		},
+		"auth_key": {
+			Type:      schema.TypeString,
+			Optional:  true,
+			Sensitive: true,
+			Description: "The authentication key to be used, should match on all the neighbors of the network segment " +
+				"(available since RouterOS 7.x).",
 		},
 		KeyComment: PropCommentRw,
 		"cost": {


### PR DESCRIPTION
I couldn't find the exact OS version on which the attribute change occurred. At least since 7.10 the attribute is new, but on 6.48 it is old.


Fixes #510