### PR TITLE
feat: Add newly introduced properties from the most recent RouterOS

### DIFF
--- a/routeros/resource_interface_bridge.go
+++ b/routeros/resource_interface_bridge.go
@@ -134,6 +134,12 @@ func ResourceInterfaceBridge() *schema.Resource {
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 			ValidateFunc:     validation.IntBetween(6, 40),
 		},
+		"max_learned_entries": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "An option to set the maximum number of learned hosts for the bridge interface. This option is available in RouterOS starting from version 7.16.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
 		"max_message_age": {
 			Type:     schema.TypeString,
 			Optional: true,

--- a/routeros/resource_interface_bridge.go
+++ b/routeros/resource_interface_bridge.go
@@ -68,6 +68,12 @@ func ResourceInterfaceBridge() *schema.Resource {
 				"bridge will start functioning normally.",
 			DiffSuppressFunc: TimeEquall,
 		},
+		"forward_reserved_addresses": {
+			Type:             schema.TypeBool,
+			Optional:         true,
+			Description:      "An option whether to forward IEEE reserved multicast MAC addresses that are in the `01:80:C2:00:00:0x` range. This option is available in RouterOS starting from version 7.16.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
 		"frame_types": {
 			Type:     schema.TypeString,
 			Optional: true,

--- a/routeros/resource_ip_dhcp_server_lease.go
+++ b/routeros/resource_ip_dhcp_server_lease.go
@@ -68,6 +68,12 @@ func ResourceDhcpServerLease() *schema.Resource {
 			Optional:    true,
 			Description: "Send all replies as broadcasts.",
 		},
+		"class_id": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Class ID of the client. This option is available in RouterOS starting from version 7.16.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
 		"block_access": {
 			Type:        schema.TypeBool,
 			Optional:    true,

--- a/routeros/resource_ip_dhcp_server_option.go
+++ b/routeros/resource_ip_dhcp_server_option.go
@@ -22,6 +22,7 @@ func ResourceDhcpServerOption() *schema.Resource {
 	resSchema := map[string]*schema.Schema{
 		MetaResourcePath: PropResourcePath("/ip/dhcp-server/option"),
 		MetaId:           PropId(Id),
+		KeyComment:       PropCommentRw,
 		"code": {
 			Type:         schema.TypeInt,
 			Required:     true,

--- a/routeros/resource_ip_dhcp_server_option_sets.go
+++ b/routeros/resource_ip_dhcp_server_option_sets.go
@@ -19,6 +19,7 @@ func ResourceDhcpServerOptionSet() *schema.Resource {
 	resSchema := map[string]*schema.Schema{
 		MetaResourcePath: PropResourcePath("/ip/dhcp-server/option/sets"),
 		MetaId:           PropId(Id),
+		KeyComment:       PropCommentRw,
 		"name": {
 			Type:        schema.TypeString,
 			Required:    true,

--- a/routeros/resource_ip_dns.go
+++ b/routeros/resource_ip_dns.go
@@ -110,6 +110,15 @@ func ResourceDns() *schema.Resource {
 			Description:  "Maximum size of allowed UDP packet. *Default: 4096*",
 			ValidateFunc: validation.IntBetween(50, 65507),
 		},
+		"mdns_repeat_ifaces": {
+			Type:        schema.TypeSet,
+			Optional:    true,
+			Description: "An option to enable mDNS repeater on specified interfaces. This option is available in RouterOS starting from version 7.16.",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
 		"query_server_timeout": {
 			Type:     schema.TypeString,
 			Optional: true,

--- a/routeros/resource_ip_neighbor_discovery.go
+++ b/routeros/resource_ip_neighbor_discovery.go
@@ -26,6 +26,13 @@ func ResourceIpNeighborDiscoverySettings() *schema.Resource {
 			Description:      "Interface list on which members the discovery protocol will run on.",
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
+		"discover_interval": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "An option to adjust the frequency at which neighbor discovery packets are transmitted. " +
+				"The setting is available since RouterOS version 7.16.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
 		"lldp_mac_phy_config": {
 			Type:     schema.TypeBool,
 			Optional: true,

--- a/routeros/resource_ip_neighbor_discovery.go
+++ b/routeros/resource_ip_neighbor_discovery.go
@@ -67,6 +67,13 @@ func ResourceIpNeighborDiscoverySettings() *schema.Resource {
 				"Equipment (PSE) and Powered Devices (PD).",
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
+		"lldp_vlan_info": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Description: "An option whether to send IEEE 802.1 Organizationally Specific TLVs in LLDP related to VLANs. " +
+				"The setting is available since RouterOS version 7.16.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
 		"mode": {
 			Type:     schema.TypeString,
 			Optional: true,

--- a/routeros/resource_ip_service.go
+++ b/routeros/resource_ip_service.go
@@ -58,6 +58,13 @@ func ResourceIpService() *schema.Resource {
 		},
 		KeyDisabled: PropDisabledRw,
 		KeyInvalid:  PropInvalidRo,
+		"max_sessions": {
+			Type:             schema.TypeInt,
+			Optional:         true,
+			Description:      "Maximum number of concurrent connections to a particular service. This option is available in RouterOS starting from version 7.16.",
+			ValidateFunc:     validation.IntAtLeast(1),
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
 		"name": {
 			Type:        schema.TypeString,
 			Computed:    true,

--- a/routeros/resource_wifi_provisioning.go
+++ b/routeros/resource_wifi_provisioning.go
@@ -65,11 +65,11 @@ func ResourceWifiProvisioning() *schema.Resource {
 			Description:  "Specify the format of the CAP interface name creation.",
 		},
 		"radio_mac": {
-			Type:         schema.TypeString,
-			Optional:     true,
-			Default:      "00:00:00:00:00:00",
-			Description:  "MAC address of radio to be matched, empty MAC (00:00:00:00:00:00) means match all MAC addresses.",
-			ValidateFunc: ValidationMacAddress,
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "MAC address of radio to be matched, empty MAC means match all MAC addresses. `00:00:00:00:00:00` is not considered empty MAC-address.",
+			ValidateFunc:     ValidationMacAddress,
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"slave_configurations": {
 			Type:     schema.TypeList,

--- a/routeros/resource_wifi_provisioning.go
+++ b/routeros/resource_wifi_provisioning.go
@@ -78,6 +78,12 @@ func ResourceWifiProvisioning() *schema.Resource {
 			Description: "If action specifies to create interfaces, then a new slave interface for each configuration " +
 				"profile in this list is created.",
 		},
+		"slave_name_format": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "The name format of the slave CAP interfaces. This option is available in RouterOS starting from version 7.16.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
 		"supported_bands": {
 			Type:     schema.TypeList,
 			Optional: true,


### PR DESCRIPTION
This PR brings the following:
- add the `comment` property support to the DHCP resources;
- remove the default value for the `radio_mac` property in the `routeros_wifi_provisioning` resource (closes #508);
- add `slave_name_format` property support to the `routeros_wifi_provisioning` resource;
- add `class_id` property support to the `routeros_ip_dhcp_server_lease` resource;
- add `forward_reserved_addresses` property support to the `routeros_interface_bridge` resource;
- add `max_sessions` property support to the `routeros_ip_service` resource;
- add `discover_interval` property support to the `routeros_ip_neighbor_discovery_settings` resource;
- add `lldp_vlan_info` property support to the `routeros_ip_neighbor_discovery_settings` resource;
- add `mdns_repeat_ifaces` property support to the `routeros_ip_dns` resource;
- add `max_learned_entries` property support to the `routeros_interface_bridge` resource.
