### PR TITLE
Fix change detection in sets with `SetUnset` values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode/*
 .idea
 pkg/*
+issues/*
 terraform-provider-routeros*
 terraform.tfstate*
 node_modules


### PR DESCRIPTION
Added policy set processing for user groups. To work correctly, we need to analyze incoming changes and modify outgoing policy set values at the same time. The minimum version for the provider build go `v1.21`, since the `slices.Contains()` function is used. Fixes #544