### PR TITLE
fix: validation for routeros_wifi_security.wps

### DIFF
--- a/routeros/resource_wifi_security.go
+++ b/routeros/resource_wifi_security.go
@@ -229,7 +229,7 @@ func ResourceWifiSecurity() *schema.Resource {
 			Type:         schema.TypeString,
 			Optional:     true,
 			Description:  "An option to enable WPS (Wi-Fi Protected Setup).",
-			ValidateFunc: validation.StringInSlice([]string{"disabled", "push-button"}, false),
+			ValidateFunc: validation.StringInSlice([]string{"disable", "push-button"}, false),
 		},
 	}
 


### PR DESCRIPTION
## Description

Fix incorrect validation added for the resource attribute `routeros_wifi_security.wps`.

Fixes #577 