### PR TITLE
docs: fix mlag import example

### DIFF
--- a/examples/resources/routeros_bridge_mlag/import.sh
+++ b/examples/resources/routeros_bridge_mlag/import.sh
@@ -1,1 +1,1 @@
-terraform import routeros_ip_cloud.test .
+terraform import routeros_bridge_mlag.mlag "/interface/bridge/mlag"

--- a/examples/resources/routeros_bridge_mlag/import.sh
+++ b/examples/resources/routeros_bridge_mlag/import.sh
@@ -1,1 +1,1 @@
-terraform import routeros_bridge_mlag.mlag "/interface/bridge/mlag"
+terraform import routeros_bridge_mlag.mlag .


### PR DESCRIPTION
Import example was wrong for the `routeros_bridge_mlag`. 