### PR TITLE
fix(ds): warning  Field 'revision' not found in the schema in routeros_system_routerboard datasource

### DIFF
--- a/routeros/datasource_system_routerboard.go
+++ b/routeros/datasource_system_routerboard.go
@@ -39,6 +39,10 @@ func DatasourceSystemRouterboard() *schema.Resource {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
+		"revision": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 		"routerboard": {
 			Type:     schema.TypeBool,
 			Computed: true,


### PR DESCRIPTION
Fixes #602