### PR TITLE
Add new resources `routeros_ipv6_firewall_nat` and `routeros_ipv6_firewall_mangle`

### DIFF
--- a/examples/resources/routeros_ipv6_firewall_mangle/import.sh
+++ b/examples/resources/routeros_ipv6_firewall_mangle/import.sh
@@ -1,0 +1,3 @@
+#The ID can be found via API or the terminal
+#The command for the terminal is -> :put [/ipv6/firewall/mangle get [print show-ids]]
+terraform import routeros_ipv6_firewall_mangle.rule "*0"

--- a/examples/resources/routeros_ipv6_firewall_mangle/resource.tf
+++ b/examples/resources/routeros_ipv6_firewall_mangle/resource.tf
@@ -1,0 +1,9 @@
+resource "routeros_ipv6_firewall_mangle" "rule" {
+  action        = "change-mss"
+  chain         = "forward"
+  out_interface = "pppoe-out"
+  protocol      = "tcp"
+  tcp_flags     = "syn"
+  new_mss       = "1130"
+  tcp_mss       = "1301-65535"
+}

--- a/examples/resources/routeros_ipv6_firewall_nat/import.sh
+++ b/examples/resources/routeros_ipv6_firewall_nat/import.sh
@@ -1,0 +1,3 @@
+#The ID can be found via API or the terminal
+#The command for the terminal is -> :put [/ipv6/firewall/nat get [print show-ids]]
+terraform import routeros_ipv6_firewall_nat.rule "*0"

--- a/examples/resources/routeros_ipv6_firewall_nat/resource.tf
+++ b/examples/resources/routeros_ipv6_firewall_nat/resource.tf
@@ -1,0 +1,5 @@
+resource "routeros_ipv6_firewall_nat" "rule" {
+  action        = "masquerade"
+  chain         = "srcnat"
+  out_interface = "ether16"
+}

--- a/routeros/datasource_ipv6_firewall.go
+++ b/routeros/datasource_ipv6_firewall.go
@@ -18,8 +18,9 @@ func DatasourceIPv6Firewall() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			MetaSkipFields: PropSkipFields("packets"),
 
-			"nat":   getIPv6FirewallNatSchema(),
-			"rules": getIPv6FirewallFilterSchema(),
+			"mangle": getIPv6FirewallMangleSchema(),
+			"nat":    getIPv6FirewallNatSchema(),
+			"rules":  getIPv6FirewallFilterSchema(),
 		},
 	}
 }

--- a/routeros/datasource_ipv6_firewall.go
+++ b/routeros/datasource_ipv6_firewall.go
@@ -18,6 +18,7 @@ func DatasourceIPv6Firewall() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			MetaSkipFields: PropSkipFields("packets"),
 
+			"nat":   getIPv6FirewallNatSchema(),
 			"rules": getIPv6FirewallFilterSchema(),
 		},
 	}

--- a/routeros/datasource_ipv6_firewall_mangle.go
+++ b/routeros/datasource_ipv6_firewall_mangle.go
@@ -1,0 +1,284 @@
+package routeros
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func getIPv6FirewallMangleSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				KeyFilter: PropFilterRw,
+				"id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"action": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"address_list": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"address_list_timeout": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"bytes": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"chain": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				KeyComment: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"connection_bytes": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"connection_limit": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"connection_mark": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"connection_nat_state": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"connection_rate": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"connection_state": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"connection_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"content": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				KeyDisabled: {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"dscp": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"dst_address": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"dst_address_list": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"dst_address_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"dst_limit": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"dst_port": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				KeyDynamic: {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				// no fragment, hotspot
+				"icmp_options": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"in_bridge_port": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"in_bridge_port_list": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"in_interface": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"in_interface_list": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"ingress_priority": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"invalid": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"ipsec_policy": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"jump_target": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				// no jump target, layer7
+				"limit": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"log": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"log_prefix": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"new_connection_mark": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"new_dscp": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"new_mss": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"new_packet_mark": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"new_priority": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"new_routing_mark": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"new_ttl": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"nth": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"out_bridge_port": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"out_bridge_port_list": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"out_interface": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"out_interface_list": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"packet_mark": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"packet_size": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"passthrough": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"per_connection_classifier": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"port": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"priority": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"protocol": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"random": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"routing_mark": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"src_address": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"src_address_list": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"src_address_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"src_port": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"src_mac_address": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tcp_flags": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tcp_mss": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"time": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tls_host": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"ttl": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}

--- a/routeros/datasource_ipv6_firewall_nat.go
+++ b/routeros/datasource_ipv6_firewall_nat.go
@@ -1,0 +1,246 @@
+package routeros
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func getIPv6FirewallNatSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Computed: true,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				KeyFilter: PropFilterRw,
+				"id": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"action": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"address_list": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"address_list_timeout": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"bytes": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"chain": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				KeyComment: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"connection_bytes": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"connection_limit": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"connection_mark": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"connection_rate": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"connection_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"content": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				KeyDisabled: {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"dscp": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"dst_address": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"dst_address_list": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"dst_address_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"dst_limit": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"dst_port": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				KeyDynamic: {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"icmp_options": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"in_bridge_port": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"in_bridge_port_list": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"in_interface": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"in_interface_list": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"ingress_priority": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"invalid": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"ipsec_policy": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"jump_target": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"limit": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"log": {
+					Type:     schema.TypeBool,
+					Computed: true,
+				},
+				"log_prefix": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"nth": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"out_bridge_port": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"out_bridge_port_list": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"out_interface": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"out_interface_list": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"packet_mark": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"packet_size": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"per_connection_classifier": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"port": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"priority": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"protocol": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"random": {
+					Type:     schema.TypeInt,
+					Computed: true,
+				},
+				"routing_mark": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"src_address": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"src_address_list": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"src_address_type": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"src_port": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"src_mac_address": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tcp_flags": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tcp_mss": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"time": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"tls_host": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"to_addresses": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+				"to_ports": {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
+			},
+		},
+	}
+}

--- a/routeros/provider.go
+++ b/routeros/provider.go
@@ -132,6 +132,7 @@ func Provider() *schema.Provider {
 			"routeros_ipv6_dhcp_server_option_sets":    ResourceIpv6DhcpServerOptionSets(),
 			"routeros_ipv6_firewall_addr_list":         ResourceIPv6FirewallAddrList(),
 			"routeros_ipv6_firewall_filter":            ResourceIPv6FirewallFilter(),
+			"routeros_ipv6_firewall_nat":               ResourceIPv6FirewallNat(),
 			"routeros_ipv6_neighbor_discovery":         ResourceIPv6NeighborDiscovery(),
 			"routeros_ipv6_pool":                       ResourceIpv6Pool(),
 			"routeros_ipv6_route":                      ResourceIPv6Route(),

--- a/routeros/provider.go
+++ b/routeros/provider.go
@@ -133,6 +133,7 @@ func Provider() *schema.Provider {
 			"routeros_ipv6_firewall_addr_list":         ResourceIPv6FirewallAddrList(),
 			"routeros_ipv6_firewall_filter":            ResourceIPv6FirewallFilter(),
 			"routeros_ipv6_firewall_nat":               ResourceIPv6FirewallNat(),
+			"routeros_ipv6_firewall_mangle":            ResourceIPv6FirewallMangle(),
 			"routeros_ipv6_neighbor_discovery":         ResourceIPv6NeighborDiscovery(),
 			"routeros_ipv6_pool":                       ResourceIpv6Pool(),
 			"routeros_ipv6_route":                      ResourceIPv6Route(),

--- a/routeros/resource_ipv6_firewall_mangle.go
+++ b/routeros/resource_ipv6_firewall_mangle.go
@@ -1,0 +1,421 @@
+package routeros
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+/*
+{
+    ".id": "*1",
+    "action": "accept",
+    "bytes": "31611",
+    "chain": "prerouting",
+    "disabled": "false",
+    "dynamic": "false",
+    "invalid": "false",
+    "log": "false",
+    "log-prefix": "",
+    "packets": "325"
+  }
+*/
+
+// ResourceIPv6FirewallMangle https://wiki.mikrotik.com/wiki/Manual:IP/Firewall/Mangle
+func ResourceIPv6FirewallMangle() *schema.Resource {
+	resSchema := map[string]*schema.Schema{
+		MetaResourcePath: PropResourcePath("/ipv6/firewall/mangle"),
+		MetaId:           PropId(Id),
+		MetaSkipFields:   PropSkipFields("bytes", "packets"),
+		MetaSetUnsetFields: PropSetUnsetFields("dst_address_list", "src_address_list", "in_interface", "in_interface_list",
+			"out_interface", "out_interface_list", "in_bridge_port_list", "out_bridge_port_list"),
+
+		"action": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Action to take if a packet is matched by the rule.",
+			ValidateFunc: validation.StringInSlice([]string{
+				"accept", "add-dst-to-address-list", "add-src-to-address-list", "change-dscp", "change-mss",
+				"change-ttl", "clear-df", "fasttrack-connection", "jump", "log", "mark-connection", "mark-packet",
+				"mark-routing", "passthrough", "return", "route", "set-priority", "sniff-pc", "sniff-tzsp",
+				"strip-ipv4-options",
+			}, false),
+		},
+		"address_list": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Name of the address list to be used. Applicable if action is add-dst-to-address-list or " +
+				"add-src-to-address-list.",
+		},
+		// Mikrotik v7.7 response - 400: 'Bad Request' (invalid time value for argument address-list-timeout)
+		// request body:  {"action":"drop","address-list-timeout":"none-dynamic", ...}
+		// The default value is empty and the field is Computed.
+		"address_list_timeout": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+			// Default:  "none-dynamic",
+			Description: "Time interval after which the address will be removed from the address list specified by " +
+				"address-list parameter. Used in conjunction with add-dst-to-address-list or add-src-to-address-list " +
+				"actions.",
+		},
+		"chain": {
+			Type:     schema.TypeString,
+			Required: true,
+			Description: "Specifies to which chain rule will be added. If the input does not match the name of an " +
+				"already defined chain, a new chain will be created.",
+		},
+		KeyComment: PropCommentRw,
+		"connection_bytes": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Matches packets only if a given amount of bytes has been transfered through the particular " +
+				"connection.",
+		},
+		"connection_limit": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Matches connections per address or address block after given value is reached. Should be " +
+				"used together with connection-state=new and/or with tcp-flags=syn because matcher is very resource " +
+				"intensive.",
+		},
+		"connection_mark": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Matches packets marked via mangle facility with particular connection mark. If no-mark is " +
+				"set, rule will match any unmarked connection.",
+		},
+		"connection_nat_state": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Can match connections that are srcnatted, dstnatted or both.",
+			ValidateDiagFunc: ValidationMultiValInSlice([]string{"srcnat", "dstnat"}, false, true),
+		},
+		// See comment for the "path_cost" field in resource_interface_bridge_port.go file.
+		"connection_rate": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Connection Rate is a firewall matcher that allow to capture traffic based on present speed " +
+				"of the connection (0..4294967295).",
+		},
+		"connection_state": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Interprets the connection tracking analysis data for a particular packet.",
+			ValidateDiagFunc: ValidationMultiValInSlice([]string{
+				"established", "invalid", "new", "related", "untracked",
+			}, false, true),
+		},
+		"connection_type": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Matches packets from related connections based on information from their connection " +
+				"tracking helpers.",
+			ValidateDiagFunc: ValidationMultiValInSlice([]string{
+				"ftp", "h323", "irc", "pptp", "quake3", "sip", "tftp",
+			}, false, true),
+		},
+		"content": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Match packets that contain specified text.",
+		},
+		KeyDisabled: PropDisabledRw,
+		"dscp": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Description:  "Matches DSCP IP header field.",
+			ValidateFunc: validation.IntBetween(0, 63),
+		},
+		"dst_address": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches packets which destination is equal to specified IP or falls into specified IP range.",
+		},
+		"dst_address_list": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches destination address of a packet against user-defined address list.",
+		},
+		"dst_address_type": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Matches destination address type.",
+			ValidateDiagFunc: ValidationMultiValInSlice([]string{"unicast", "local", "broadcast", "multicast", "blackhole"}, false, true),
+		},
+		"dst_limit": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches packets until a given rate is exceeded.",
+		},
+		"dst_port": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "List of destination port numbers or port number ranges.",
+		},
+		KeyDynamic: PropDynamicRo,
+		"icmp_options": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches ICMP type: code fields.",
+		},
+		"in_bridge_port": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Actual interface the packet has entered the router if the incoming interface is a bridge. " +
+				"Works only if use-ip-firewall is enabled in bridge settings.",
+		},
+		"in_bridge_port_list": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Set of interfaces defined in interface list. Works the same as in-bridge-port.",
+		},
+		"in_interface": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Interface the packet has entered the router.",
+		},
+		"in_interface_list": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Set of interfaces defined in interface list. Works the same as in-interface.",
+		},
+		"ingress_priority": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Description: "Matches the priority of an ingress packet. Priority may be derived from VLAN, WMM, DSCP, " +
+				"or MPLS EXP bit.",
+			ValidateFunc: validation.IntBetween(0, 63),
+		},
+		"invalid": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		"ipsec_policy": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches the policy used by IPsec. Value is written in the following format: direction, policy.",
+			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^(in|out)\s?,\s?(ipsec|none)$`),
+				"Value must be written in the following format: direction, policy."),
+		},
+		"limit": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Matches packets up to a limited rate (packet rate or bit rate). A rule using this matcher " +
+				"will match until this limit is reached. Parameters are written in the following format: " +
+				"rate[/time],burst:mode.",
+		},
+		"log": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Add a message to the system log.",
+		},
+		"log_prefix": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Adds specified text at the beginning of every log message. Applicable if action=log or " +
+				"log=yes configured.",
+		},
+		"new_connection_mark": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Sets a new connection-mark value.",
+		},
+		"new_dscp": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Description:  "Sets a new DSCP value for a packet.",
+			ValidateFunc: validation.IntBetween(0, 63),
+		},
+		"new_mss": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: `Sets a new MSS for a packet.  
+	> clamp-to-pmtu feature sets (DF) bit in the IP header to dynamically discover the PMTU of a path.  
+	> Host sends all datagrams on that path with the DF bit set until receives ICMP.  
+	> Destination Unreachable messages with a code meaning "fragmentation needed and DF set".    
+	> Upon receipt of such a message, the source host reduces its assumed PMTU for the path.  
+`,
+			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^(\d+|clamp-to-pmtu)$`),
+				`Value must be a number in quotes or the string "clamp-to-pmtu".`),
+		},
+		"new_packet_mark": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Sets a new packet-mark value.",
+		},
+		"new_priority": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Sets a new priority for a packet. This can be the VLAN, WMM, DSCP or MPLS EXP priority. " +
+				"This property can also be used to set an internal priority.",
+		},
+		"new_routing_mark": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Sets a new routing-mark value.",
+		},
+		"new_ttl": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Sets a new TTL for a packet.",
+		},
+		"nth": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Matches every nth packet: nth=2,1 rule will match every first packet of 2, hence, 50% of " +
+				"all the traffic that is matched by the rule",
+		},
+		"out_bridge_port": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Actual interface the packet is leaving the router if the outgoing interface is a bridge. " +
+				"Works only if use-ip-firewall is enabled in bridge settings.",
+		},
+		"out_bridge_port_list": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Set of interfaces defined in interface list. Works the same as out-bridge-port.",
+		},
+		"out_interface": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Interface the packet is leaving the router.",
+		},
+		"out_interface_list": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Set of interfaces defined in interface list. Works the same as out-interface.",
+		},
+		"packet_mark": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Matches packets marked via mangle facility with particular packet mark. If no-mark is set, " +
+				"the rule will match any unmarked packet.",
+		},
+		"packet_size": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches packets of specified size or size range in bytes.",
+		},
+		"passthrough": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Computed: true,
+			Description: "Whether to let the packet to pass further (like action passthrough) into the " +
+				"firewall or not (property only valid some actions).",
+		},
+		"per_connection_classifier": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "PCC matcher allows dividing traffic into equal streams with the ability to keep packets " +
+				"with a specific set of options in one particular stream.",
+		},
+		KeyPlaceBefore: PropPlaceBefore,
+		"port": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Matches if any (source or destination) port matches the specified list of ports or port " +
+				"ranges. Applicable only if protocol is TCP or UDP",
+		},
+		"priority": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Description: "Matches the packet's priority after a new priority has been set. Priority may be derived from " +
+				"VLAN, WMM, DSCP, MPLS EXP bit, or from the priority that has been set using the set-priority action.",
+			ValidateFunc: validation.IntBetween(0, 63),
+		},
+		"protocol": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches particular IP protocol specified by protocol name or number.",
+		},
+		"random": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Description:  "Matches packets randomly with a given probability.",
+			ValidateFunc: validation.IntBetween(1, 99),
+		},
+		"routing_mark": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches packets marked by mangle facility with particular routing mark.",
+		},
+		"src_address": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches packets which source is equal to specified IP or falls into a specified IP range.",
+		},
+		"src_address_list": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches source address of a packet against user-defined address list.",
+		},
+		"src_address_type": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Matches source address type.",
+			ValidateDiagFunc: ValidationMultiValInSlice([]string{"unicast", "local", "broadcast", "multicast"}, false, true),
+		},
+		"src_port": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "List of source ports and ranges of source ports. Applicable only if a protocol is TCP or UDP.",
+		},
+		"src_mac_address": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "Matches source MAC address of the packet.",
+			ValidateFunc: validation.IsMACAddress,
+		},
+		"tcp_flags": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches specified TCP flags.",
+		},
+		"tcp_mss": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches TCP MSS value of an IP packet.",
+		},
+		"time": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Allows to create a filter based on the packets' arrival time and date or, for locally " +
+				"generated packets, departure time and date.",
+		},
+		"tls_host": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Allows matching HTTPS traffic based on TLS SNI hostname.",
+		},
+		"ttl": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches packets TTL value.",
+		},
+	}
+	return &schema.Resource{
+		CreateContext: DefaultCreate(resSchema),
+		ReadContext:   DefaultRead(resSchema),
+		UpdateContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+			skip := resSchema[MetaSkipFields].Default.(string)
+			resSchema[MetaSkipFields].Default = skip + `,"place_before"`
+			defer func() {
+				resSchema[MetaSkipFields].Default = skip
+			}()
+
+			return ResourceUpdate(ctx, resSchema, d, m)
+		},
+		DeleteContext: DefaultDelete(resSchema),
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: resSchema,
+	}
+}

--- a/routeros/resource_ipv6_firewall_mangle_test.go
+++ b/routeros/resource_ipv6_firewall_mangle_test.go
@@ -1,0 +1,49 @@
+package routeros
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+const testIPv6FirewallMangle = "routeros_ipv6_firewall_mangle.data"
+
+func TestAccIPv6FirewallMangleTest_basic(t *testing.T) {
+	for _, name := range testNames {
+		t.Run(name, func(t *testing.T) {
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(t)
+					testSetTransportEnv(t, name)
+				},
+				ProviderFactories: testAccProviderFactories,
+				CheckDestroy:      testCheckResourceDestroy("/ipv6/firewall/mangle", "routeros_ipv6_firewall_mangle"),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccIPv6FirewallMangleConfig(),
+						Check: resource.ComposeTestCheckFunc(
+							testResourcePrimaryInstanceId(testIPv6FirewallMangle),
+							resource.TestCheckResourceAttr(testIPv6FirewallMangle, "chain", "prerouting"),
+							resource.TestCheckResourceAttr(testIPv6FirewallMangle, "action", "mark-connection"),
+							resource.TestCheckResourceAttr(testIPv6FirewallMangle, "new_connection_mark", "test-mark"),
+						),
+					},
+				},
+			})
+
+		})
+	}
+}
+
+func testAccIPv6FirewallMangleConfig() string {
+	return providerConfig + `
+
+resource "routeros_ipv6_firewall_mangle" "data" {
+	chain = "prerouting"	
+	action = "mark-connection"
+	new_connection_mark = "test-mark"
+	comment = "new-mangle-rule"
+}
+
+`
+}

--- a/routeros/resource_ipv6_firewall_nat.go
+++ b/routeros/resource_ipv6_firewall_nat.go
@@ -1,0 +1,362 @@
+package routeros
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+/*
+ {
+    ".id": "*2",
+    "action": "masquerade",
+    "bytes": "0",
+    "chain": "srcnat",
+    "disabled": "false",
+    "dynamic": "false",
+    "invalid": "false",
+    "log": "false",
+    "log-prefix": "",
+    "out-interface": "all-wireless",
+    "packets": "0",
+    "src-address-list": "LAN"
+  }
+*/
+
+// ResourceIPv6FirewallNat https://help.mikrotik.com/docs/display/ROS/NAT
+func ResourceIPv6FirewallNat() *schema.Resource {
+	resSchema := map[string]*schema.Schema{
+		MetaResourcePath: PropResourcePath("/ipv6/firewall/nat"),
+		MetaId:           PropId(Id),
+		MetaSkipFields:   PropSkipFields("bytes", "packets"),
+		MetaSetUnsetFields: PropSetUnsetFields("dst_address_list", "src_address_list", "in_interface", "in_interface_list",
+			"out_interface", "out_interface_list", "in_bridge_port_list", "out_bridge_port_list"),
+
+		"action": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Action to take if a packet is matched by the rule",
+			ValidateFunc: validation.StringInSlice([]string{
+				"accept", "add-dst-to-address-list", "add-src-to-address-list", "dst-nat", "endpoint-independent-nat",
+				"jump", "log", "masquerade", "netmap", "passthrough", "redirect", "return", "same", "src-nat",
+			}, false),
+		},
+		"address_list": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Name of the address list to be used. Applicable if action is add-dst-to-address-list or " +
+				"add-src-to-address-list.",
+		},
+		"address_list_timeout": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Time interval after which the address will be removed from the address list specified by " +
+				"address-list parameter. Used in conjunction with add-dst-to-address-list or add-src-to-address-list " +
+				"actions.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
+		"chain": {
+			Type:     schema.TypeString,
+			Required: true,
+			Description: "Specifies to which chain rule will be added. If the input does not match the name of an " +
+				"already defined chain, a new chain will be created.",
+		},
+		KeyComment: PropCommentRw,
+		"connection_bytes": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Matches packets only if a given amount of bytes has been transfered through the particular " +
+				"connection.",
+		},
+		"connection_limit": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Matches connections per address or address block after given value is reached. Should be " +
+				"used together with connection-state=new and/or with tcp-flags=syn because matcher is very resource " +
+				"intensive.",
+		},
+		"connection_mark": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Matches packets marked via mangle facility with particular connection mark. If no-mark is " +
+				"set, rule will match any unmarked connection.",
+		},
+		// See comment for the "path_cost" field in resource_interface_bridge_port.go file.
+		"connection_rate": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Connection Rate is a firewall matcher that allow to capture traffic based on present speed " +
+				"of the connection (0..4294967295).",
+		},
+		"connection_type": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Matches packets from related connections based on information from their connection " +
+				"tracking helpers.",
+			ValidateDiagFunc: ValidationMultiValInSlice([]string{
+				"ftp", "h323", "irc", "pptp", "quake3", "sip", "tftp",
+			}, false, true),
+		},
+		"content": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Match packets that contain specified text.",
+		},
+		KeyDisabled: PropDisabledRw,
+		"dscp": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Description:  "Matches DSCP IP header field.",
+			ValidateFunc: validation.IntBetween(0, 63),
+		},
+		"dst_address": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches packets which destination is equal to specified IP or falls into specified IP range.",
+		},
+		"dst_address_list": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches destination address of a packet against user-defined address list.",
+		},
+		"dst_address_type": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Matches destination address type.",
+			ValidateDiagFunc: ValidationMultiValInSlice([]string{"unicast", "local", "broadcast", "multicast"}, false, true),
+		},
+		"dst_limit": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches packets until a given rate is exceeded.",
+		},
+		"dst_port": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "List of destination port numbers or port number ranges.",
+		},
+		KeyDynamic: PropDynamicRo,
+		// fragment, hotspot.
+		"icmp_options": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches ICMP type: code fields.",
+		},
+		"in_bridge_port": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Actual interface the packet has entered the router if the incoming interface is a bridge. " +
+				"Works only if use-ip-firewall is enabled in bridge settings.",
+		},
+		"in_bridge_port_list": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Set of interfaces defined in interface list. Works the same as in-bridge-port.",
+		},
+		"in_interface": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Interface the packet has entered the router.",
+		},
+		"in_interface_list": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Set of interfaces defined in interface list. Works the same as in-interface.",
+		},
+		"ingress_priority": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Description: "Matches the priority of an ingress packet. Priority may be derived from VLAN, WMM, DSCP, " +
+				"or MPLS EXP bit.",
+			ValidateFunc: validation.IntBetween(0, 63),
+		},
+		"invalid": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		"ipsec_policy": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches the policy used by IPsec. Value is written in the following format: direction, policy.",
+			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^(in|out)\s?,\s?(ipsec|none)$`),
+				"Value must be written in the following format: direction, policy."),
+		},
+		"jump_target": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Name of the target chain to jump to. Applicable only if action=jump.",
+		},
+		// No layer7 protocol
+		"limit": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Matches packets up to a limited rate (packet rate or bit rate). A rule using this matcher " +
+				"will match until this limit is reached. Parameters are written in the following format: " +
+				"rate[/time],burst:mode.",
+		},
+		"log": {
+			Type:             schema.TypeBool,
+			Optional:         true,
+			Description:      "Add a message to the system log.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
+		"log_prefix": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Adds specified text at the beginning of every log message. Applicable if action=log or " +
+				"log=yes configured.",
+		},
+		"nth": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Matches every nth packet: nth=2,1 rule will match every first packet of 2, hence, 50% of " +
+				"all the traffic that is matched by the rule",
+		},
+		"out_bridge_port": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Actual interface the packet is leaving the router if the outgoing interface is a bridge. " +
+				"Works only if use-ip-firewall is enabled in bridge settings.",
+		},
+		"out_bridge_port_list": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Set of interfaces defined in interface list. Works the same as out-bridge-port.",
+		},
+		"out_interface": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Interface the packet is leaving the router.",
+		},
+		"out_interface_list": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Set of interfaces defined in interface list. Works the same as out-interface.",
+		},
+		"packet_mark": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Matches packets marked via mangle facility with particular packet mark. If no-mark is set, " +
+				"the rule will match any unmarked packet.",
+		},
+		"packet_size": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches packets of specified size or size range in bytes.",
+		},
+		KeyPlaceBefore: PropPlaceBefore,
+		"port": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Matches if any (source or destination) port matches the specified list of ports or port " +
+				"ranges. Applicable only if protocol is TCP or UDP",
+		},
+		"priority": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Description: "Matches the packet's priority after a new priority has been set. Priority may be derived from " +
+				"VLAN, WMM, DSCP, MPLS EXP bit, or from the priority that has been set using the set-priority action.",
+			ValidateFunc: validation.IntBetween(0, 63),
+		},
+		"protocol": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches particular IP protocol specified by protocol name or number.",
+		},
+		// No psd
+		"random": {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Description:  "Matches packets randomly with a given probability.",
+			ValidateFunc: validation.IntBetween(1, 99),
+		},
+		"randomise_ports": {
+			Type:             schema.TypeBool,
+			Optional:         true,
+			Description:      "Randomize to which public port connections will be mapped.",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
+		"routing_mark": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches packets marked by mangle facility with particular routing mark.",
+		},
+		"src_address": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches packets which source is equal to specified IP or falls into a specified IP range.",
+		},
+		"src_address_list": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches source address of a packet against user-defined address list.",
+		},
+		"src_address_type": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Description:      "Matches source address type.",
+			ValidateDiagFunc: ValidationMultiValInSlice([]string{"unicast", "local", "broadcast", "multicast"}, false, true),
+		},
+		"src_port": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "List of source ports and ranges of source ports. Applicable only if a protocol is TCP or UDP.",
+		},
+		"src_mac_address": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "Matches source MAC address of the packet.",
+			ValidateFunc: validation.IsMACAddress,
+		},
+		"tcp_mss": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches TCP MSS value of an IP packet.",
+		},
+		"time": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Allows to create a filter based on the packets' arrival time and date or, for locally " +
+				"generated packets, departure time and date.",
+		},
+		"to_addresses": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Replace original address with specified one. Applicable if action is dst-nat, netmap, " +
+				"same, src-nat.",
+		},
+		"to_ports": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Replace the original port with the specified one. Applicable if action is dst-nat, " +
+				"redirect, masquerade, netmap, same, src-nat.",
+		},
+		"ttl": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Matches packets TTL value.",
+		},
+	}
+	return &schema.Resource{
+		CreateContext: DefaultCreate(resSchema),
+		ReadContext:   DefaultRead(resSchema),
+		UpdateContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+			skip := resSchema[MetaSkipFields].Default.(string)
+			resSchema[MetaSkipFields].Default = skip + `,"place_before"`
+			defer func() {
+				resSchema[MetaSkipFields].Default = skip
+			}()
+
+			return ResourceUpdate(ctx, resSchema, d, m)
+		},
+		DeleteContext: DefaultDelete(resSchema),
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: resSchema,
+	}
+}

--- a/routeros/resource_ipv6_firewall_nat_test.go
+++ b/routeros/resource_ipv6_firewall_nat_test.go
@@ -1,0 +1,49 @@
+package routeros
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+const testIPv6FirewallNat = "routeros_ipv6_firewall_nat.data"
+
+func TestAccIPv6FirewallNatTest_basic(t *testing.T) {
+	for _, name := range testNames {
+		t.Run(name, func(t *testing.T) {
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(t)
+					testSetTransportEnv(t, name)
+				},
+				ProviderFactories: testAccProviderFactories,
+				CheckDestroy:      testCheckResourceDestroy("/ipv6/firewall/nat", "routeros_ipv6_firewall_nat"),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccIPv6FirewallNatConfig(),
+						Check: resource.ComposeTestCheckFunc(
+							testResourcePrimaryInstanceId(testIPv6FirewallNat),
+							resource.TestCheckResourceAttr(testIPv6FirewallNat, "chain", "srcnat"),
+							resource.TestCheckResourceAttr(testIPv6FirewallNat, "action", "masquerade"),
+							resource.TestCheckResourceAttr(testIPv6FirewallNat, "disabled", "true"),
+						),
+					},
+				},
+			})
+
+		})
+	}
+}
+
+func testAccIPv6FirewallNatConfig() string {
+	return providerConfig + `
+
+resource "routeros_ipv6_firewall_nat" "data" {
+	chain = "srcnat"	
+	action = "masquerade"
+	disabled = true
+	comment = "new-nat-rule"
+}
+
+`
+}


### PR DESCRIPTION
Add `routeros_ipv6_firewall_nat` and `routeros_ipv6_firewall_mangle` which were still missing I need.

Behavior should pretty much match the ipv4 version minus the missing options.