### PR TITLE
fix(datasource_routeros_interface_bridge_filter): Returned data key should be `filters`

### DIFF
--- a/routeros/datasource_interface_bridge_filter.go
+++ b/routeros/datasource_interface_bridge_filter.go
@@ -78,5 +78,5 @@ func datasourceInterfaceBridgeFiltersRead(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(err)
 	}
 
-	return MikrotikResourceDataToTerraformDatasource(res, "data", s, d)
+	return MikrotikResourceDataToTerraformDatasource(res, "filters", s, d)
 }


### PR DESCRIPTION
Fixes a bug that results in an empty data object every time due to: `[MikrotikResourceDataToTerraformDatasource] the datasource Schema field was lost during development: ▷ 'data' ◁`

[Schema](https://github.com/terraform-routeros/terraform-provider-routeros/blob/a97fe34287072f1993e8134ab31f3909d37fe024/routeros/datasource_interface_bridge_filter.go#L20) shows the key is `filters`