### PR TITLE
fix(logging) Field 'regex' not found in the schema / routeros_system_logging

### DIFF
--- a/routeros/resource_system_logging.go
+++ b/routeros/resource_system_logging.go
@@ -33,27 +33,30 @@ func ResourceSystemLogging() *schema.Resource {
 	resSchema := map[string]*schema.Schema{
 		MetaResourcePath: PropResourcePath("/system/logging"),
 		MetaId:           PropId(Id),
+
 		"action": {
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: "specifies one of the system default actions or user specified action listed in actions menu",
 		},
-		KeyDefault: PropDefaultRo,
+		KeyDefault:  PropDefaultRo,
+		KeyDisabled: PropDisabledRw,
+		"invalid": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
 		"prefix": {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "prefix added at the beginning of log messages",
 			Default:     "",
 		},
-		KeyDisabled: {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     false,
-			Description: "Whether or not this logging should be disabled",
-		},
-		"invalid": {
-			Type:     schema.TypeBool,
-			Computed: true,
+		"regex": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: "Regex which will be used in order to match or not match message. If the regex is not matched, " +
+				"then even if topic is configured to be logged, but log message does not match regex, action will not " +
+				"be performed.",
 		},
 		"topics": {
 			Type: schema.TypeSet,


### PR DESCRIPTION
Fixes #667