### PR TITLE
WIP: allow importing containers without unnecessary recreating

### DIFF
--- a/examples/resources/routeros_container_mounts/import.sh
+++ b/examples/resources/routeros_container_mounts/import.sh
@@ -1,3 +1,2 @@
-#The ID can be found via API or the terminal
-#The command for the terminal is -> :put [/container/mounts get [print show-ids]]
-terraform import routeros_container_mounts.caddyfile "*1"
+# Import with the name of the container mount in case of the example use Caddyfile
+terraform import routeros_container_mounts.caddyfile Caddyfile


### PR DESCRIPTION
As mentioned in #652, there is an inconsistency in the documenation on how to properly import container mounts.

Moreover, a suggestion implementation on how to use computed fields `tag` (ROS < 7.18), `repo` (ROS >=7.18) to repopulate the `remote_image` write-only field.