### PR TITLE
fix: minutes short name is lower m

### DIFF
--- a/routeros/provider_schema_helpers.go
+++ b/routeros/provider_schema_helpers.go
@@ -233,8 +233,8 @@ var (
 		Optional: true,
 		Description: "ARP timeout is time how long ARP record is kept in ARP table after no packets are received " +
 			"from IP. Value auto equals to the value of arp-timeout in IP/Settings, default is 30s. Can use postfix " +
-			"`ms`, `s`, `M`, `h`, `d` for milliseconds, seconds, minutes, hours or days. If no postfix is set then seconds (s) is used.",
-		ValidateFunc: validation.StringMatch(regexp.MustCompile(`^$|auto$|(\d+(ms|s|M|h|d)?)+$`),
+			"`ms`, `s`, `m`, `h`, `d` for milliseconds, seconds, minutes, hours or days. If no postfix is set then seconds (s) is used.",
+		ValidateFunc: validation.StringMatch(regexp.MustCompile(`^$|auto$|(\d+(ms|s|m|h|d)?)+$`),
 			"expected arp_timout value to be 'auto' string or time value"),
 		DiffSuppressFunc: AlwaysPresentNotUserProvided,
 	}

--- a/routeros/resource_interface_vrrp.go
+++ b/routeros/resource_interface_vrrp.go
@@ -98,7 +98,7 @@ func ResourceInterfaceVrrp() *schema.Resource {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "VRRP update interval in seconds. Defines how often master sends advertisement packets.",
-			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^(\d+(ms|s|M)?)+$`),
+			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^(\d+(ms|s|m)?)+$`),
 				"expected hello interval 10ms..4m15s"),
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},

--- a/routeros/resource_interface_vrrp_v0.go
+++ b/routeros/resource_interface_vrrp_v0.go
@@ -47,7 +47,7 @@ func ResourceInterfaceVrrpV0() *schema.Resource {
 				Optional:    true,
 				Default:     "1s",
 				Description: "VRRP update interval in seconds. Defines how often master sends advertisement packets.",
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^(\d+(ms|s|M)?)+$`),
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^(\d+(ms|s|m)?)+$`),
 					"expected hello interval 10ms..4m15s"),
 			},
 			"invalid": {


### PR DESCRIPTION
The short char for minutes is a lower 'm' not the upper. (upper is for month, but i dont think mikrotik is use anywhere)

This patch fix that.