### PR TITLE
fix: `routeros_interfaces` data source schema is missing "inactive" field

### DIFF
--- a/docs/data-sources/interfaces.md
+++ b/docs/data-sources/interfaces.md
@@ -29,6 +29,7 @@ Read-Only:
 - `disabled` (Boolean)
 - `dynamic` (Boolean)
 - `id` (String)
+- `inactive` (Boolean)
 - `l2mtu` (Number)
 - `last_link_down_time` (String)
 - `last_link_up_time` (String)

--- a/routeros/datasource_interfaces.go
+++ b/routeros/datasource_interfaces.go
@@ -48,6 +48,10 @@ func DatasourceInterfaces() *schema.Resource {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
+						"inactive": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
 						"l2mtu": {
 							Type:     schema.TypeInt,
 							Computed: true,


### PR DESCRIPTION
Fixes the following warning:
```
╷
│ Warning: Field 'inactive' not found in the schema
│ 
│   with data.routeros_interfaces.main,
│   on main.tf line 57, in data "routeros_interfaces" "main":
│   57: data "routeros_interfaces" "main" {
│ 
│ [MikrotikResourceDataToTerraformDatasource] the field was lost during the Schema development: ▷ 'inactive': 'false' ◁
╵
```
The `inactive` field is present (at least) on `type=lte` interfaces.