### PR TITLE
Implement duration check

### DIFF
--- a/routeros/provider_schema_helpers.go
+++ b/routeros/provider_schema_helpers.go
@@ -532,6 +532,26 @@ var (
 		}
 	}
 
+	// ValidationDurationBetween returns a SchemaValidateFunc which tests if the provided value
+	// is a valid duration expected by RouterOS and is between minVal and maxVal (inclusive)
+	ValidationDurationBetween = func(minVal, maxVal int) schema.SchemaValidateFunc {
+		return func(i interface{}, k string) (warnings []string, errors []error) {
+			value, ok := i.(string)
+			if !ok {
+				errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+				return warnings, errors
+			}
+
+			duration, err := ParseDuration(value, time.Second)
+			if err != nil {
+				errors = append(errors, fmt.Errorf("expected %q to be a valid time, got %q: %+v", k, i, err))
+				return warnings, errors
+			}
+
+			return validation.IntBetween(minVal, maxVal)(int(duration.Seconds()), k)
+		}
+	}
+
 	ValidationAutoYesNo = validation.StringInSlice([]string{"auto", "yes", "no"}, false)
 	ValidationIpAddress = validation.StringMatch(
 		regexp.MustCompile(`^$|^!?(\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(/([0-9]|[0-9]|[1-2][0-9]|3[0-2]))?)$`),

--- a/routeros/resource_interface_wireguard_peer.go
+++ b/routeros/resource_interface_wireguard_peer.go
@@ -104,7 +104,8 @@ func ResourceInterfaceWireguardPeer() *schema.Resource {
 				"persistently. For example, if the interface very rarely sends traffic, but it might at anytime " +
 				"receive traffic from a peer, and it is behind NAT, the interface might benefit from having a " +
 				"persistent keepalive interval of 25 seconds.",
-			ValidateFunc: ValidationDurationBetween(1, 65535),
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+			ValidateFunc:     ValidationDurationBetween(1, 65535),
 		},
 		"preshared_key": {
 			Type:      schema.TypeString,

--- a/routeros/resource_interface_wireguard_peer.go
+++ b/routeros/resource_interface_wireguard_peer.go
@@ -1,10 +1,7 @@
 package routeros
 
 import (
-	"regexp"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 // ResourceInterfaceWireguardPeer https://help.mikrotik.com/docs/display/ROS/WireGuard#WireGuard-Peers
@@ -107,10 +104,7 @@ func ResourceInterfaceWireguardPeer() *schema.Resource {
 				"persistently. For example, if the interface very rarely sends traffic, but it might at anytime " +
 				"receive traffic from a peer, and it is behind NAT, the interface might benefit from having a " +
 				"persistent keepalive interval of 25 seconds.",
-			ValidateFunc: validation.StringMatch(
-				regexp.MustCompile(`^\d+s$`),
-				"value should be an integer between 1 and 65535 inclusive: 5s, 25s, ...",
-			),
+			ValidateFunc: ValidationDurationBetween(1, 65535),
 		},
 		"preshared_key": {
 			Type:      schema.TypeString,


### PR DESCRIPTION
Fix wireguard peer persistent-keepalive validation: it's time duration (5s, 10m, 1h, etc).

You can set a decimal value, but mikrotik will convert it to duration, so terraform always want to change it to integer back.

