### PR TITLE
fix(wg-peers): Fix drift attributes

### DIFF
--- a/routeros/mikrotik_resource_drift_implementation.go
+++ b/routeros/mikrotik_resource_drift_implementation.go
@@ -73,9 +73,9 @@ func (do *driftObjects) GetDriftMap(ros, resName string, reverse bool) (res map[
 		log.Fatal(err)
 	}
 
+	res = map[string]string{}
 	for i := range *do {
 		if version >= (*do)[i].Version {
-			res = map[string]string{}
 			for _, attr := range (*do)[i].Resources[resName] {
 				if !reverse {
 					res[attr.TF] = attr.MT


### PR DESCRIPTION
The result map was located in the wrong place.
[ROS 7.18, 1.85.0] wireguard peers' responder/is_responder parameter broken again
Fixes #750