### PR TITLE
fix(bridge_port): Add new attributes (ROS 7.19)

### DIFF
--- a/routeros/resource_interface_bridge_port.go
+++ b/routeros/resource_interface_bridge_port.go
@@ -30,7 +30,9 @@ dtimes: Msg:256 Max: 5120 FD: 3840 HT: 512\n
 dprio: RBI: 8000:744D288FCA7D RPC: 10 BI: 8000:C4AD3407AD79 tP: 0x2 rP: 0x2\n
 ",
     "designated-bridge": "0x8000.74:4D:28:8F:CA:7D",
+    "designated-bridge-id": "0x8000.74:4D:28:8F:CA:7D",
     "designated-cost": "0",
+    "designated-port-id": "0x80.6",
     "designated-port-number": "1",
     "disabled": "false",
     "dynamic": "false",
@@ -39,6 +41,7 @@ dprio: RBI: 8000:744D288FCA7D RPC: 10 BI: 8000:C4AD3407AD79 tP: 0x2 rP: 0x2\n
     "edge-port-discovery": "true",
     "external-fdb-status": "false",
     "fast-leave": "false",
+    "forward-transitions": "1",
     "forwarding": "true",
     "frame-types": "admit-only-vlan-tagged",
     "horizon": "none",
@@ -55,16 +58,22 @@ dprio: RBI: 8000:744D288FCA7D RPC: 10 BI: 8000:C4AD3407AD79 tP: 0x2 rP: 0x2\n
     "point-to-point": "auto",
     "point-to-point-port": "true",
     "port-number": "2",
+    "port-id": "0x80.2",
     "priority": "0x80",
     "pvid": "1",
     "restricted-role": "false",
     "restricted-tcn": "false",
     "role": "root-port",
+    "rx-bpdu": "0",
+    "rx-tc": "0",
     "root-path-cost": "10",
     "sending-rstp": "true",
     "status": "in-bridge",
     "tag-stacking": "false",
+    "topology-changes": "0",
     "trusted": "false",
+    "tx-bpdu": "2157",
+    "tx-tc": "0",
     "unknown-multicast-flood": "true",
     "unknown-unicast-flood": "true"
   },
@@ -114,10 +123,20 @@ func ResourceInterfaceBridgePort() *schema.Resource {
 			Computed:    true,
 			Description: "Root bridge ID (bridge priority and the bridge MAC address).",
 		},
+		"designated_bridge_id": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Shows the designated bridge identifier, as determined from the port's priority vector.",
+		},
 		"designated_cost": {
 			Type:        schema.TypeString,
 			Computed:    true,
 			Description: "Designated cost.",
+		},
+		"designated_port_id": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Shows the designated port identifier, as determined from the port's priority vector.",
 		},
 		"designated_port_number": {
 			Type:        schema.TypeInt,
@@ -125,6 +144,11 @@ func ResourceInterfaceBridgePort() *schema.Resource {
 			Description: "Designated port number.",
 		},
 		KeyDisabled: PropDisabledRw,
+		"discard_transitions": {
+			Type:        schema.TypeInt,
+			Computed:    true,
+			Description: "Counter, registring how often port transitions into discarding state.",
+		},
 		KeyDynamic:  PropDynamicRo,
 		"edge": {
 			Type:     schema.TypeString,
@@ -155,6 +179,11 @@ func ResourceInterfaceBridgePort() *schema.Resource {
 			Optional:         true,
 			Description:      "Enables IGMP Fast leave feature on the port.",
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
+		"forward_transitions": {
+			Type:        schema.TypeInt,
+			Computed:    true,
+			Description: "Counter, registring how often port transitions into forwarding state.",
 		},
 		"forwarding": {
 			Type:        schema.TypeBool,
@@ -212,6 +241,11 @@ func ResourceInterfaceBridgePort() *schema.Resource {
 			Description: "Path cost to the interface for MSTI0 inside a region. This property only has effect when " +
 				"protocol-mode is set to mstp.",
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
+		"last_topology_change": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Last topology change timer, records time since the last change.",
 		},
 		"learn": {
 			Type:             schema.TypeString,
@@ -276,6 +310,11 @@ func ResourceInterfaceBridgePort() *schema.Resource {
 			Type:        schema.TypeBool,
 			Computed:    true,
 			Description: "Whether the port is connected to a bridge port using full-duplex (true) or half-duplex (false).",
+		},
+		"port_id": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "In Spanning Tree Protocol each port has a unique Port Identifier. Priority[hex] + port number.",
 		},
 		"priority": {
 			Type:     schema.TypeString,
@@ -365,6 +404,16 @@ func ResourceInterfaceBridgePort() *schema.Resource {
 			Computed:    true,
 			Description: "The total cost of the path to the root-bridge.",
 		},
+		"rx_bpdu": {
+			Type:        schema.TypeInt,
+			Computed:    true,
+			Description: "Received bpdu messages counter.",
+		},
+		"rx_tc": {
+			Type:        schema.TypeInt,
+			Computed:    true,
+			Description: "Topology change messages received.",
+		},
 		"sending_rstp": {
 			Type:     schema.TypeString,
 			Computed: true,
@@ -385,6 +434,11 @@ func ResourceInterfaceBridgePort() *schema.Resource {
 				"This property only has effect when vlan-filtering is set to yes.",
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
+		"topology_changes": {
+			Type:        schema.TypeInt,
+			Computed:    true,
+			Description: "Topology change counter.",
+		},
 		"trusted": {
 			Type:     schema.TypeBool,
 			Optional: true,
@@ -392,6 +446,16 @@ func ResourceInterfaceBridgePort() *schema.Resource {
 				"Mainly used to limit unauthorized servers to provide malicious information for users. " +
 				"This property only has effect when dhcp-snooping is set to yes.",
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+		},
+		"tx_bpdu": {
+			Type:        schema.TypeInt,
+			Computed:    true,
+			Description: "Sent bpdu messages counter.",
+		},
+		"tx_tc": {
+			Type:        schema.TypeInt,
+			Computed:    true,
+			Description: "Topology change messages sent.",
 		},
 		"unknown_multicast_flood": {
 			Type:             schema.TypeBool,

--- a/routeros/resource_interface_bridge_port.go
+++ b/routeros/resource_interface_bridge_port.go
@@ -85,7 +85,8 @@ func ResourceInterfaceBridgePort() *schema.Resource {
 	resSchema := map[string]*schema.Schema{
 		MetaResourcePath: PropResourcePath("/interface/bridge/port"),
 		MetaId:           PropId(Id),
-		MetaSkipFields:   PropSkipFields("debug_info", "port_number"),
+		MetaSkipFields: PropSkipFields("debug_info", "discard_transitions", "forward_transitions", "port_number",
+			"rx_bpdu", "rx_tc", "topology_changes", "tx_bpdu", "tx_tc"),
 
 		"nextid": {
 			Type:     schema.TypeString,
@@ -144,11 +145,6 @@ func ResourceInterfaceBridgePort() *schema.Resource {
 			Description: "Designated port number.",
 		},
 		KeyDisabled: PropDisabledRw,
-		"discard_transitions": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Counter, registring how often port transitions into discarding state.",
-		},
 		KeyDynamic:  PropDynamicRo,
 		"edge": {
 			Type:     schema.TypeString,
@@ -179,11 +175,6 @@ func ResourceInterfaceBridgePort() *schema.Resource {
 			Optional:         true,
 			Description:      "Enables IGMP Fast leave feature on the port.",
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
-		},
-		"forward_transitions": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Counter, registring how often port transitions into forwarding state.",
 		},
 		"forwarding": {
 			Type:        schema.TypeBool,
@@ -404,16 +395,6 @@ func ResourceInterfaceBridgePort() *schema.Resource {
 			Computed:    true,
 			Description: "The total cost of the path to the root-bridge.",
 		},
-		"rx_bpdu": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Received bpdu messages counter.",
-		},
-		"rx_tc": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Topology change messages received.",
-		},
 		"sending_rstp": {
 			Type:     schema.TypeString,
 			Computed: true,
@@ -434,11 +415,6 @@ func ResourceInterfaceBridgePort() *schema.Resource {
 				"This property only has effect when vlan-filtering is set to yes.",
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
-		"topology_changes": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Topology change counter.",
-		},
 		"trusted": {
 			Type:     schema.TypeBool,
 			Optional: true,
@@ -446,16 +422,6 @@ func ResourceInterfaceBridgePort() *schema.Resource {
 				"Mainly used to limit unauthorized servers to provide malicious information for users. " +
 				"This property only has effect when dhcp-snooping is set to yes.",
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
-		},
-		"tx_bpdu": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Sent bpdu messages counter.",
-		},
-		"tx_tc": {
-			Type:        schema.TypeInt,
-			Computed:    true,
-			Description: "Topology change messages sent.",
 		},
 		"unknown_multicast_flood": {
 			Type:             schema.TypeBool,


### PR DESCRIPTION
Hello,

This should fix the following warnings :
> Warning: Field 'designated_bridge_id' not found in the schema
>   Warning: Field 'designated_port_id' not found in the schema
>   Warning: Field 'discard_transitions' not found in the schema
>   Warning: Field 'forward_transitions' not found in the schema
>   Warning: Field 'last_topology_change' not found in the schema
>   Warning: Field 'port_id' not found in the schema
>   Warning: Field 'rx_bpdu' not found in the schema
>   Warning: Field 'rx_tc' not found in the schema
>   Warning: Field 'topology_changes' not found in the schema
>   Warning: Field 'tx_bpdu' not found in the schema
>   Warning: Field 'tx_tc' not found in the schema

