### PR TITLE
fix: bgp connection property address-family has been renamed to afi

### DIFF
--- a/docs/resources/routing_bgp_connection.md
+++ b/docs/resources/routing_bgp_connection.md
@@ -14,7 +14,7 @@
 ### Optional
 
 - `add_path_out` (String)
-- `address_families` (String) List of address families about which this peer will exchange routing information. The remote peer must support (they usually do) BGP capabilities optional parameter to negotiate any other families than IP.
+- `afi` (String) List of address families about which this peer will exchange routing information. The remote peer must support (they usually do) BGP capabilities optional parameter to negotiate any other families than IP.
 - `cisco_vpls_nlri_len_fmt` (String) VPLS NLRI length format type. Used for compatibility with Cisco VPLS.
 - `cluster_id` (String) In case this instance is a route reflector: the cluster ID of the router reflector cluster to this instance belongs. This attribute helps to recognize routing updates that come from another route reflector in this cluster and avoid routing information looping. Note that normally there is only one route reflector in a cluster; in this case, 'cluster-id' does not need to be configured and BGP router ID is used instead.
 - `comment` (String)

--- a/docs/resources/routing_bgp_template.md
+++ b/docs/resources/routing_bgp_template.md
@@ -14,7 +14,7 @@
 ### Optional
 
 - `add_path_out` (String)
-- `address_families` (String) List of address families about which this peer will exchange routing information. The remote peer must support (they usually do) BGP capabilities optional parameter to negotiate any other families than IP.
+- `afi` (String) List of address families about which this peer will exchange routing information. The remote peer must support (they usually do) BGP capabilities optional parameter to negotiate any other families than IP.
 - `as_override` (Boolean) If set, then all instances of the remote peer's AS number in the BGP AS-PATH attribute are replaced with the local AS number before sending a route update to that peer. Happens before routing filters and prepending.
 - `cisco_vpls_nlri_len_fmt` (String) VPLS NLRI length format type. Used for compatibility with Cisco VPLS.
 - `cluster_id` (String) In case this instance is a route reflector: the cluster ID of the router reflector cluster to this instance belongs. This attribute helps to recognize routing updates that come from another route reflector in this cluster and avoid routing information looping. Note that normally there is only one route reflector in a cluster; in this case, 'cluster-id' does not need to be configured and BGP router ID is used instead.

--- a/routeros/resource_bgp_connection.go
+++ b/routeros/resource_bgp_connection.go
@@ -9,7 +9,7 @@ import (
      {
     ".id": "*1",
     "add-path-out": "none",
-    "address-families": "ip",
+    "afi": "ip",
     "as": "65521/1",
     "as-override": "true",
     "cisco-vpls-nlri-len-fmt": "auto-bits",
@@ -76,7 +76,7 @@ func ResourceRoutingBGPConnection() *schema.Resource {
 			Default:      "none",
 			ValidateFunc: validation.StringInSlice([]string{"all", "none"}, false),
 		},
-		"address_families": {
+		"afi": {
 			Type:     schema.TypeString,
 			Optional: true,
 			Default:  "ip",

--- a/routeros/resource_bgp_connection_test.go
+++ b/routeros/resource_bgp_connection_test.go
@@ -42,7 +42,7 @@ func testAccBGPConnectionConfig() string {
 	return providerConfig + `
 resource "routeros_routing_bgp_connection" "test" {
 	add_path_out            = "none"
-	address_families        = "ip"
+	afi                     = "ip"
 	as                      = "65550/5"
 	cisco_vpls_nlri_len_fmt = "auto-bits"
 	cluster_id              = "0.0.0.0"

--- a/routeros/resource_bgp_template.go
+++ b/routeros/resource_bgp_template.go
@@ -10,7 +10,7 @@ import (
 	".about": "invalid value '0.0.0.0' of 'router-id'",
 	".id": "*2",
 	"add-path-out": "all",
-	"address-families": "ip,ipv6,l2vpn,l2vpn-cisco,vpnv4",
+	"afi": "ip,ipv6,l2vpn,l2vpn-cisco,vpnv4",
 	"as": "65000",
 	"as-override": "true",
 	"cisco-vpls-nlri-len-fmt": "auto-bits",
@@ -64,7 +64,7 @@ func ResourceRoutingBGPTemplate() *schema.Resource {
 			Default:      "none",
 			ValidateFunc: validation.StringInSlice([]string{"all", "none"}, false),
 		},
-		"address_families": {
+		"afi": {
 			Type:     schema.TypeString,
 			Optional: true,
 			Default:  "ip",


### PR DESCRIPTION
Hey folks,

It seems that in `resource_bgp_connection` object a property has been renamed and introduced a breaking change.
This pull request aims to fix this property.

I did not find anything in changelog but I identified [this change in the documentation ](https://help.mikrotik.com/docs/pages/diffpagesbyversion.action?pageId=328220&selectedPageVersions=79&selectedPageVersions=78) that shows the rename of the property. Also, I compiled these modifications locally and applied my code, it works well (and so fix the issue I had).

**Current Behavior**

API rejects requests with 400 because `address_families` is unknown

**Expected Behavior**

API accepts requests and creates resources

Thanks!

