### PR TITLE
Fix(ipsec): Correct validation for my_id and remote_id attributes in ipsec_identity

### DIFF
--- a/routeros/resource_ip_ipsec_identity.go
+++ b/routeros/resource_ip_ipsec_identity.go
@@ -103,7 +103,6 @@ func ResourceIpIpsecIdentity() *schema.Resource {
 				"based connections; `address` - IP address is used as ID;dn - the binary Distinguished Encoding Rules (DER) " +
 				"encoding of an ASN.1 X.500 Distinguished Name; `fqdn` - fully qualified domain name; `key-id` - use the specified " +
 				"key ID for the identity; `user-fqdn` - specifies a fully-qualified username string, for example, `user@domain.com`.",
-			ValidateFunc:     validation.StringInSlice([]string{"auto", "address", "fqdn", "user-fqdn", "key-id"}, false),
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"notrack_chain": {
@@ -152,7 +151,6 @@ func ResourceIpIpsecIdentity() *schema.Resource {
 				"Only supported in IKEv2; `key-id` - specific key ID for the identity. Only supported in IKEv2; `ignore` - " +
 				"do not verify received ID with certificate (dangerous). * Wildcard key ID matching **is not supported**, " +
 				"for example `remote-id=`key-id:CN=*.domain.com`.",
-			ValidateFunc:     validation.StringInSlice([]string{"auto", "fqdn", "user-fqdn", "key-id", "ignore"}, false),
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"remote_key": {


### PR DESCRIPTION
This pull request corrects the validation for the `my_id` and `remote_id` attributes in the `routeros_ip_ipsec_identity` resource.

By removing the `ValidateFunc`, this change allows users to provide the required `type:value` string format (e.g., "user-fqdn:user@example.com"), which was previously impossible.

Fixes #774 