### PR TITLE
 fix: routeros_ipv6_nd_prefix data source schema is missing "invalid" field

### DIFF
--- a/docs/resources/ipv6_nd_prefix.md
+++ b/docs/resources/ipv6_nd_prefix.md
@@ -31,6 +31,7 @@ resource "routeros_ipv6_nd_prefix" "test" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `invalid` (Boolean)
 
 ## Import
 Import is supported using the following syntax:

--- a/routeros/resource_ipv6_nd_prefix.go
+++ b/routeros/resource_ipv6_nd_prefix.go
@@ -49,6 +49,7 @@ func ResourceIpv6NdPrefix() *schema.Resource {
 			Required:    true,
 			Description: "Interface name on which stateless auto-configuration will be running.",
 		},
+		KeyInvalid: PropInvalidRo,
 		"on_link": {
 			Type:     schema.TypeBool,
 			Optional: true,


### PR DESCRIPTION
Fixes the following warning:
```terraform
╷
│ Warning: Field 'invalid' not found in the schema
│ 
│   with routeros_ipv6_nd_prefix.iot,
│   on router-ipv6.tf line 16, in resource "routeros_ipv6_nd_prefix" "iot":
│   16: resource "routeros_ipv6_nd_prefix" "iot" {
│ 
│ [MikrotikResourceDataToTerraform] The field was lost during the Schema development: ▷ 'invalid': 'false' ◁
╵
```