### PR TITLE
Add DefaultReadFiltered, filter `ip_dhcp_server_lease` resource reads based on `dynamic` field

### DIFF
--- a/routeros/resource_actions_default.go
+++ b/routeros/resource_actions_default.go
@@ -38,6 +38,12 @@ func DefaultRead(s map[string]*schema.Schema) schema.ReadContextFunc {
 	}
 }
 
+func DefaultReadFiltered(s map[string]*schema.Schema, filters map[string]interface{}) schema.ReadContextFunc {
+	return func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+		return ResourceReadFilter(ctx, s, d, m, filters)
+	}
+}
+
 func DefaultUpdate(s map[string]*schema.Schema) schema.UpdateContextFunc {
 	return func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 		return ResourceUpdate(ctx, s, d, m)

--- a/routeros/resource_ip_dhcp_server_lease.go
+++ b/routeros/resource_ip_dhcp_server_lease.go
@@ -176,7 +176,7 @@ func ResourceDhcpServerLease() *schema.Resource {
 		Description: "Creates a DHCP lease on the mikrotik device.",
 
 		CreateContext: DefaultCreate(resSchema),
-		ReadContext:   DefaultRead(resSchema),
+		ReadContext:   DefaultReadFiltered(resSchema, map[string]interface{}{"dynamic": "no"}),
 		UpdateContext: DefaultUpdate(resSchema),
 		DeleteContext: DefaultDelete(resSchema),
 		Importer: &schema.ResourceImporter{


### PR DESCRIPTION
The setup that I have currently is that I have a bootstrap script that sets up the devices in a state where I can run `terraform apply` against that, regardless of the existing state in terraform. This is admittedly a bit cursed but bear with me.

The problem I'm facing is with dhcp leases, where MikroTik seemingly doesn't separate between dynamic leases and static ones in their IDs.
This then causes a problem where the ID that terraform state has for the static lease is currently a dynamic lease, which results in `Error: PATCH 'https://10.1.1.2/rest/ip/dhcp-server/lease/*1' returned response code: 400, message: 'Bad Request', details: 'failure: can not change dynamic lease'`.

As dynamic leases can not be changed anyways, probably would be okay to add filtering on the read of `routeros_ip_dhcp_server_lease` that filters out dynamic leases with `dynamic=no`.

Did this with adding a `DefaultReadFiltered` as well as two more underlying functions to mimic `DefaultRead`, and then calling it `routeros/resource_ip_dhcp_server_lease.go`.

Tested this at least locally and it works for my use case and doesn't seem to cause any weirdness.

Please let me know if this makes any sense, I'm new to terraform providers so there's also that.
