### PR TITLE
fix(ip_hotspot_user_profile) Fix the attribute type `shared_users`, as the value can be `unlimited`

### DIFF
--- a/routeros/resource_ip_hotspot_user_profile.go
+++ b/routeros/resource_ip_hotspot_user_profile.go
@@ -204,7 +204,7 @@ func ResourceIpHotspotUserProfile() *schema.Resource {
 			DiffSuppressFunc: TimeEqual,
 		},
 		"shared_users": {
-			Type:             schema.TypeInt,
+			Type:             schema.TypeString, // Maybe "unlimited".
 			Optional:         true,
 			Description:      "Allowed number of simultaneously logged in users with the same HotSpot username.",
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,


### PR DESCRIPTION
Fixes #803