### PR TITLE
Add initial devcontainer configuration

### DIFF
--- a/.devcontainer/.vscode/tasks.json
+++ b/.devcontainer/.vscode/tasks.json
@@ -1,0 +1,22 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build Terraform Provider",
+      "type": "shell",
+      "command": "go build *.go && mkdir -p ~/.terraform.d/plugins/terraform.local/local/routeros/1.0.0/$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m) && mv main ~/.terraform.d/plugins/terraform.local/local/routeros/1.0.0/$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m)/terraform-provider-routeros_v1.0.0",
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": true
+      }
+    }
+  ]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+	"name": "Go",
+	"image": "mcr.microsoft.com/devcontainers/go:2-1.24-bookworm",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"golang.go"
+			]
+		}
+	},
+	"mounts": [
+		"source=${env:HOME}${env:USERPROFILE}/.config,target=/home/vscode/.config,type=bind",
+		"source=${env:HOME}${env:USERPROFILE}/.terraform.d,target=/home/vscode/.terraform.d,type=bind"
+	]
+}


### PR DESCRIPTION
This is an initial devcontainer configuration based on the official (by Microsoft) go container, and with the golang extension, plus 2 mounts: 
- ~/.config is to let through user configuration, eg. their .gitignore. My use case for this is I use the `xyz.local-history` extension, and have the .history folder in my user .gitignore.
- ~/.terraform.d to be able to use the built provider in other projects for testing, according to README.md instructions (these don't work for me, but maybe it's my set up)

The `task.json` file is to allow building with ctrl+b