### PR TITLE
Do not override inherited wifi attributes

### DIFF
--- a/routeros/mikrotik_serialize.go
+++ b/routeros/mikrotik_serialize.go
@@ -156,6 +156,9 @@ func TerraformResourceDataToMikrotik(s map[string]*schema.Schema, d *schema.Reso
 			case MetaTransformSet, MetaSkipFields, MetaSetUnsetFields, MetaDropByValue:
 				continue
 			default:
+				if meta.Meta == nil {
+					meta.Meta = make(map[string]string)
+				}
 				meta.Meta[terraformSnakeName] = terraformMetadata.Default.(string)
 			}
 			continue

--- a/routeros/provider_schema_helpers.go
+++ b/routeros/provider_schema_helpers.go
@@ -22,6 +22,7 @@ const (
 	MetaSkipFields     = "___skip___"
 	MetaSetUnsetFields = "___unset___"
 	MetaDropByValue    = "___drop_val___"
+	MetaNoInherited    = "___no_inherited___"
 )
 
 const (
@@ -59,6 +60,10 @@ const (
 	KeyRunning                 = "running"
 	KeyVrf                     = "vrf"
 	KeyVlanId                  = "vlan_id"
+)
+
+const (
+	ParamConfig                = "config"
 )
 
 // PropResourcePath Resource path property.
@@ -144,6 +149,19 @@ func PropSetUnsetFields(s ...string) *schema.Schema {
 		Optional:    true,
 		Default:     toQuotedCommaSeparatedString(s...),
 		Description: "<em>A set of fields that require setting/unsetting. This is an internal service field, setting a value is not required.</em>",
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			return true
+		},
+	}
+}
+
+// PropNoInherited property.
+func PropNoInherited(p string) *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Default:     p,
+		Description: "<em>Extra print parameter to suppress embedding inherited values.</em>",
 		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 			return true
 		},

--- a/routeros/resource_file.go
+++ b/routeros/resource_file.go
@@ -70,7 +70,7 @@ func ResourceFile() *schema.Resource {
 		DeleteContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 			metadata := GetMetadata(resSchema)
 
-			id, err := dynamicIdLookup(metadata.IdType, metadata.Path, m.(Client), d)
+			id, err := dynamicIdLookup(metadata.IdType, metadata.Path, m.(Client), d, metadata)
 			if err != nil {
 				if err != errorNoLongerExists {
 					ColorizedDebug(ctx, fmt.Sprintf(ErrorMsgDelete, err))

--- a/routeros/resource_routing_table.go
+++ b/routeros/resource_routing_table.go
@@ -143,7 +143,7 @@ func ResourceRoutingTable() *schema.Resource {
 				}
 			}
 
-			id, err := dynamicIdLookup(metadata.IdType, metadata.Path, m.(Client), d)
+			id, err := dynamicIdLookup(metadata.IdType, metadata.Path, m.(Client), d, metadata)
 			if err != nil {
 				// There is nothing to update, because resource id not found
 				// or some other error.

--- a/routeros/resource_system_logging_actions.go
+++ b/routeros/resource_system_logging_actions.go
@@ -169,7 +169,7 @@ func ResourceSystemLoggingAction() *schema.Resource {
 		switch d.Get("name").(string) {
 		case "disk", "echo", "memory", "remote":
 			d.SetId(d.Get("name").(string))
-			id, err := dynamicIdLookup(Name, resSchema[MetaResourcePath].Default.(string), m.(Client), d)
+			id, err := dynamicIdLookup(Name, resSchema[MetaResourcePath].Default.(string), m.(Client), d, nil)
 			if err != nil {
 				ColorizedDebug(ctx, fmt.Sprintf(ErrorMsgPatch, err))
 				return diag.FromErr(err)

--- a/routeros/resource_wifi.go
+++ b/routeros/resource_wifi.go
@@ -36,6 +36,7 @@ func ResourceWifi() *schema.Resource {
 		MetaId:           PropId(Id),
 		MetaTransformSet: PropTransformSet("aaa.config: aaa", "channel.config: channel", "configuration.config: configuration",
 			"datapath.config: datapath", "interworking.config: interworking", "security.config: security", "steering.config: steering"),
+		MetaNoInherited:  PropNoInherited(ParamConfig),
 
 		"aaa": {
 			Type:             schema.TypeMap,
@@ -43,7 +44,6 @@ func ResourceWifi() *schema.Resource {
 			Elem:             &schema.Schema{Type: schema.TypeString},
 			Description:      "AAA inline settings.",
 			ValidateDiagFunc: ValidationMapKeyNames,
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		KeyArp:        PropArpRw,
 		KeyArpTimeout: PropArpTimeoutRw,
@@ -58,7 +58,6 @@ func ResourceWifi() *schema.Resource {
 			Elem:             &schema.Schema{Type: schema.TypeString},
 			Description:      "Channel inline settings.",
 			ValidateDiagFunc: ValidationMapKeyNames,
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"configuration": {
 			Type:             schema.TypeMap,
@@ -66,7 +65,6 @@ func ResourceWifi() *schema.Resource {
 			Elem:             &schema.Schema{Type: schema.TypeString},
 			Description:      "Configuration inline settings.",
 			ValidateDiagFunc: ValidationMapKeyNames,
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"datapath": {
 			Type:             schema.TypeMap,
@@ -74,7 +72,6 @@ func ResourceWifi() *schema.Resource {
 			Elem:             &schema.Schema{Type: schema.TypeString},
 			Description:      "Datapath inline settings.",
 			ValidateDiagFunc: ValidationMapKeyNames,
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		KeyComment:     PropCommentRw,
 		KeyDefaultName: PropDefaultNameRo("The interface's default name."),
@@ -104,7 +101,6 @@ func ResourceWifi() *schema.Resource {
 			Elem:             &schema.Schema{Type: schema.TypeString},
 			Description:      "Interworking inline settings.",
 			ValidateDiagFunc: ValidationMapKeyNames,
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		KeyL2Mtu: PropL2MtuRw,
 		"mac_address": {
@@ -147,7 +143,6 @@ func ResourceWifi() *schema.Resource {
 			Elem:             &schema.Schema{Type: schema.TypeString},
 			Description:      "Security inline settings.",
 			ValidateDiagFunc: ValidationMapKeyNames,
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"steering": {
 			Type:             schema.TypeMap,
@@ -155,7 +150,6 @@ func ResourceWifi() *schema.Resource {
 			Elem:             &schema.Schema{Type: schema.TypeString},
 			Description:      "Steering inline settings.",
 			ValidateDiagFunc: ValidationMapKeyNames,
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 	}
 

--- a/routeros/resource_wifi_configuration.go
+++ b/routeros/resource_wifi_configuration.go
@@ -40,6 +40,7 @@ func ResourceWifiConfiguration() *schema.Resource {
 		MetaId:           PropId(Id),
 		MetaTransformSet: PropTransformSet("aaa.config: aaa", "channel.config: channel", "datapath.config: datapath",
 			"interworking.config: interworking", "security.config: security", "steering.config: steering"),
+		MetaNoInherited:  PropNoInherited(ParamConfig),
 
 		"aaa": {
 			Type:             schema.TypeMap,
@@ -47,7 +48,6 @@ func ResourceWifiConfiguration() *schema.Resource {
 			Elem:             &schema.Schema{Type: schema.TypeString},
 			Description:      "AAA inline settings.",
 			ValidateDiagFunc: ValidationMapKeyNames,
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"antenna_gain": {
 			Type:         schema.TypeInt,
@@ -76,7 +76,6 @@ func ResourceWifiConfiguration() *schema.Resource {
 			Elem:             &schema.Schema{Type: schema.TypeString},
 			Description:      "Channel inline settings.",
 			ValidateDiagFunc: ValidationMapKeyNames,
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		KeyComment: PropCommentRw,
 		"country": {
@@ -90,7 +89,6 @@ func ResourceWifiConfiguration() *schema.Resource {
 			Elem:             &schema.Schema{Type: schema.TypeString},
 			Description:      "Datapath inline settings.",
 			ValidateDiagFunc: ValidationMapKeyNames,
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"deprioritize_unii_3_4": {
 			Type:     schema.TypeBool,
@@ -120,7 +118,6 @@ func ResourceWifiConfiguration() *schema.Resource {
 			Elem:             &schema.Schema{Type: schema.TypeString},
 			Description:      "Interworking inline settings.",
 			ValidateDiagFunc: ValidationMapKeyNames,
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"manager": {
 			Type:         schema.TypeString,
@@ -153,7 +150,6 @@ func ResourceWifiConfiguration() *schema.Resource {
 			Elem:             &schema.Schema{Type: schema.TypeString},
 			Description:      "Security inline settings.",
 			ValidateDiagFunc: ValidationMapKeyNames,
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"ssid": {
 			Type:        schema.TypeString,
@@ -166,7 +162,6 @@ func ResourceWifiConfiguration() *schema.Resource {
 			Elem:             &schema.Schema{Type: schema.TypeString},
 			Description:      "Steering inline settings.",
 			ValidateDiagFunc: ValidationMapKeyNames,
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"tx_chains": {
 			Type:     schema.TypeSet,


### PR DESCRIPTION
routeros_wifi_configuration & friends offer a nice way to abstract out most of the wifi related settings, if one e.g. wants to ensure consistency between 2.4Ghz and 5Ghz or between similar-but-not-quite-the-same VLANs/SSIDs. However, using Terraform currently breaks that, because the provider cannot distinguish between attributes defined directly vs. ones inherited from another resource (configuration, security, channel etc.). The first time the provider updates a wifi interface, it writes all the inherited attributes as direct ones, breaking the inheritance.

This PR tries to address that, however, it is not quite perfect, so it may not be ready for merging.

The important part is using "/print config" instead of plain "/print" for resources which support it. This makes Terraform see only the direct attributes.

Note that at the moment this works only when using Mikrotik's API (api:// or apis://), I could not figure out how to achieve similar functionality over the HTTP(s) REST API. I don't know how this difference between the two APIs should be handled in the provider.

An important consequence of this change is Terraform taking ownership over all attributes of the affected resources. If an attribute is set via e.g. the web UI but is not mentioned in the Terraform configuration, then the provider will try to clear it. If that is not desired, then the standard Terraform "lifecycle { ignore_changes = ... }" construct can be used to tell Terraform which attributes should it leave alone.

Apart from the lack of REST API support, there is one oddity which I did not manage to sort out: if an inheritance section is cleared on the web UI (e.g., removing the reference to a datapath from a wifi configuration), then Terraform does not detect the drift, and it does not try to restore the setting.

Comments are welcome.