### PR TITLE
Move dynamic IP/services to new attr on data source

### DIFF
--- a/docs/data-sources/ip_services.md
+++ b/docs/data-sources/ip_services.md
@@ -64,8 +64,10 @@ Read-Only:
 - `dynamic` (Boolean)
 - `id` (String)
 - `invalid` (String)
+- `max_sessions` (Number)
 - `name` (String)
 - `port` (Number)
+- `proto` (String)
 - `tls_version` (String)
 - `vrf` (String)
 

--- a/routeros/datasource_ip_services.go
+++ b/routeros/datasource_ip_services.go
@@ -116,12 +116,20 @@ func DatasourceIPServices() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"max_sessions": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
 						"name": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
 						"port": {
 							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"proto": {
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 						"tls_version": {


### PR DESCRIPTION
This fixes a regression in `data.routeros_ip_services` in that 7.19 introduced 'dynamic' services & connections there, and `name` is no longer (with those included) unique. They're also much less if at all useful from a configuration perspective.

Here, I've (1) excluded them from `data.routeros_ip_services.*.services`, so that it behaves as it did pre-7.19; (2) added `data.routeros_ip_services.*.dynamic_services`, with exactly those excluded from the former; (3) added `proto` (TCP/UDP) and `max_sessions` fields to the schema of both, which was causing warnings otherwise. (I'm not sure which ROS version introduced those.)

Closes #896.