### PR TITLE
Fix ambiguous (null) stop signal

### DIFF
--- a/routeros/resource_container.go
+++ b/routeros/resource_container.go
@@ -174,6 +174,7 @@ func ResourceContainer() *schema.Resource {
 		"stop_signal": {
 			Type:        schema.TypeString,
 			Optional:    true,
+			Default:     "15-SIGTERM",
 			Description: "Signal to stop the container.",
 		},
 		"tag": {


### PR DESCRIPTION
When unspecified, the provider would try to remove the ROS default of `"15-SIGTERM"` on second apply.