### PR TITLE
Replace dashes with underscores in routeros ip ipsec identity example

### DIFF
--- a/docs/resources/ip_ipsec_identity.md
+++ b/docs/resources/ip_ipsec_identity.md
@@ -15,11 +15,11 @@ resource "routeros_ip_ipsec_peer" "test" {
 }
 
 resource "routeros_ip_ipsec_identity" "test" {
-  auth-method     = "eap"
+  auth_method     = "eap"
   certificate     = ""
-  eap-methods     = "eap-mschapv2"
-  generate-policy = "port-strict"
-  mode-config     = routeros_ip_ipsec_mode_config.test.name
+  eap_methods     = "eap-mschapv2"
+  generate_policy = "port-strict"
+  mode_config     = routeros_ip_ipsec_mode_config.test.name
   peer            = routeros_ip_ipsec_peer.test.name
   username        = "support@mikrotik.com"
   password        = "secret"

--- a/examples/resources/routeros_ip_ipsec_identity/resource.tf
+++ b/examples/resources/routeros_ip_ipsec_identity/resource.tf
@@ -10,11 +10,11 @@ resource "routeros_ip_ipsec_peer" "test" {
 }
 
 resource "routeros_ip_ipsec_identity" "test" {
-  auth-method     = "eap"
+  auth_method     = "eap"
   certificate     = ""
-  eap-methods     = "eap-mschapv2"
-  generate-policy = "port-strict"
-  mode-config     = routeros_ip_ipsec_mode_config.test.name
+  eap_methods     = "eap-mschapv2"
+  generate_policy = "port-strict"
+  mode_config     = routeros_ip_ipsec_mode_config.test.name
   peer            = routeros_ip_ipsec_peer.test.name
   username        = "support@mikrotik.com"
   password        = "secret"


### PR DESCRIPTION
After copying the existing example for `routeros_ip_ipsec_identity` I got `Error: Unsupported argument` for the following fields:
- auth-method
- eap-methods
- generate-policy
- mode-config

Changing the dashes (`-`) to underscores (`_`) fixed the errors.