### PR TITLE
Fix some erroneously suppressed diffs with proper defaults

### DIFF
--- a/routeros/resource_interface_bridge.go
+++ b/routeros/resource_interface_bridge.go
@@ -104,12 +104,11 @@ func ResourceInterfaceBridge() *schema.Resource {
 		"ingress_filtering": {
 			Type:     schema.TypeBool,
 			Optional: true,
+			Default:  true,
 			Description: "Enables or disables VLAN ingress filtering, which checks if the ingress port is a member " +
 				"of the received VLAN ID in the bridge VLAN table. Should be used with frame-types to specify if " +
 				"the ingress traffic should be tagged or untagged. This property only has effect when " +
 				"vlan-filtering is set to yes.",
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
-			RequiredWith:     []string{"vlan_filtering"},
 		},
 		KeyL2Mtu: PropL2MtuRo,
 		"last_member_interval": {
@@ -238,11 +237,11 @@ func ResourceInterfaceBridge() *schema.Resource {
 		"pvid": {
 			Type:     schema.TypeInt,
 			Optional: true,
+			Default:  1,
 			Description: "Port VLAN ID (pvid) specifies which VLAN the untagged ingress traffic is assigned to. " +
 				"It applies e.g. to frames sent from bridge IP and destined to a bridge port. " +
 				"This property only has effect when vlan-filtering is set to yes.",
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
-			ValidateFunc:     validation.IntBetween(1, 4094),
+			ValidateFunc: validation.IntBetween(1, 4094),
 		},
 		"querier_interval": {
 			Type:     schema.TypeString,
@@ -311,10 +310,10 @@ func ResourceInterfaceBridge() *schema.Resource {
 			ValidateFunc:     validation.IntBetween(1, 10),
 		},
 		"vlan_filtering": {
-			Type:             schema.TypeBool,
-			Optional:         true,
-			Description:      "Globally enables or disables VLAN functionality for bridge.",
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Globally enables or disables VLAN functionality for bridge.",
 		},
 		// Some properties are not implemented, see: https://wiki.mikrotik.com/wiki/Manual:Interface/Bridge
 	}

--- a/routeros/resource_interface_bridge_filter.go
+++ b/routeros/resource_interface_bridge_filter.go
@@ -187,8 +187,8 @@ func ResourceInterfaceBridgeFilter() *schema.Resource {
 		"log": {
 			Type:             schema.TypeBool,
 			Optional:         true,
+			Default:          false,
 			Description:      "Add a message to the system log.",
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"log_prefix": {
 			Type:     schema.TypeString,

--- a/routeros/resource_interface_bridge_port.go
+++ b/routeros/resource_interface_bridge_port.go
@@ -184,9 +184,9 @@ func ResourceInterfaceBridgePort() *schema.Resource {
 		"frame_types": {
 			Type:     schema.TypeString,
 			Optional: true,
+			Default:  "admit-all",
 			Description: "Specifies allowed ingress frame types on a bridge port. " +
 				"This property only has effect when vlan-filtering is set to yes.",
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 			ValidateFunc: validation.StringInSlice([]string{"admit-all",
 				"admit-only-untagged-and-priority-tagged",
 				"admit-only-vlan-tagged"}, false),

--- a/routeros/resource_ip_dns.go
+++ b/routeros/resource_ip_dns.go
@@ -117,7 +117,6 @@ func ResourceDns() *schema.Resource {
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"query_server_timeout": {
 			Type:     schema.TypeString,

--- a/routeros/resource_ip_firewall_filter.go
+++ b/routeros/resource_ip_firewall_filter.go
@@ -228,8 +228,8 @@ func ResourceIPFirewallFilter() *schema.Resource {
 		"log": {
 			Type:             schema.TypeBool,
 			Optional:         true,
+			Default:          false,
 			Description:      "Add a message to the system log.",
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"log_prefix": {
 			Type:     schema.TypeString,

--- a/routeros/resource_ip_firewall_nat.go
+++ b/routeros/resource_ip_firewall_nat.go
@@ -225,8 +225,8 @@ func ResourceIPFirewallNat() *schema.Resource {
 		"log": {
 			Type:             schema.TypeBool,
 			Optional:         true,
+			Default:          false,
 			Description:      "Add a message to the system log.",
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"log_prefix": {
 			Type:     schema.TypeString,

--- a/routeros/resource_ip_firewall_raw.go
+++ b/routeros/resource_ip_firewall_raw.go
@@ -183,8 +183,8 @@ func ResourceIPFirewallRaw() *schema.Resource {
 		"log": {
 			Type:             schema.TypeBool,
 			Optional:         true,
+			Default:          false,
 			Description:      "Add a message to the system log.",
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"log_prefix": {
 			Type:     schema.TypeString,

--- a/routeros/resource_ipv6_firewall_nat.go
+++ b/routeros/resource_ipv6_firewall_nat.go
@@ -200,8 +200,8 @@ func ResourceIPv6FirewallNat() *schema.Resource {
 		"log": {
 			Type:             schema.TypeBool,
 			Optional:         true,
+			Default:          false,
 			Description:      "Add a message to the system log.",
-			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"log_prefix": {
 			Type:     schema.TypeString,


### PR DESCRIPTION
I appreciate the intent of `AlwaysPresentNotUserProvided`, but I think in at least most cases it unfortunately can't be used, and is causing erroneous diff suppressions where it is:

Suppose you apply a filter rule with `log=true`, check it out in WebFig, decide it's good, and untick `log` in the UI. On next `terraform apply` you *should* see it want to:
```
  log = false -> true
```
but due to `AlwaysPresentNotUserProvided`, prior to this commit, it will suppress that diff and not want to revert the manual change.

Similarly, if `mdns_repeat_ifaces` is not initially specified, then added in the UI, terraform will continue ignoring it until/unless explicitly added in terraform config.

In my view this makes for quite a gotcha: anything can happen to parameters that are not explicitly specified in configuration, the plan will look clean, and yet they're not in code at all, but may well be relied upon values.