### PR TITLE
fix(ipsec): add IPSec missing algorithms

### DIFF
--- a/routeros/resource_ip_ipsec_profile.go
+++ b/routeros/resource_ip_ipsec_profile.go
@@ -34,7 +34,7 @@ func ResourceIpIpsecProfile() *schema.Resource {
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 				ValidateFunc: validation.StringInSlice([]string{"modp768", "modp1024", "modp1536", "modp2048",
-					"modp3072", "modp4096", "modp6144", "modp8192", "ecp256", "ecp384", "ecp521"}, false),
+					"modp3072", "modp4096", "modp6144", "modp8192", "ecp256", "ecp384", "ecp521", "x25519"}, false),
 			},
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},

--- a/routeros/resource_ip_ipsec_proposal.go
+++ b/routeros/resource_ip_ipsec_proposal.go
@@ -44,9 +44,9 @@ func ResourceIpIpsecProposal() *schema.Resource {
 			Description: "Allowed algorithms and key lengths to use for SAs.",
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
-				ValidateFunc: validation.StringInSlice([]string{"null", "des", "3des", "aes-128-cbc", "aes-128-cbc",
+				ValidateFunc: validation.StringInSlice([]string{"null", "des", "3des", "aes-128-cbc", "aes-128-ctr",
 					"aes-128-gcm", "aes-192-cbc", "aes-192-ctr", "aes-192-gcm", "aes-256-cbc", "aes-256-ctr", "aes-256-gcm",
-					"blowfish", "camellia-128", "camellia-192", "camellia-256", "twofish"}, false),
+					"blowfish", "camellia-128", "camellia-192", "camellia-256", "twofish", "chacha20poly1305"}, false),
 			},
 			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},


### PR DESCRIPTION
This PR adds some missing IPSec algorithms  in Mikrotik 7.x and fixes a typo causing aes-128-ctr to be absent in Mikrotik 7.x.

Tested on a RouterOS 7.20.2.