### PR TITLE
fix: always-allow-password-login rename [7.21]

### DIFF
--- a/routeros/mikrotik_resource_drift.go
+++ b/routeros/mikrotik_resource_drift.go
@@ -12,5 +12,6 @@ func init() {
     driftAttributeSlice.Add("7.20", "/container/config", "ram_high", "memory-high")
     driftAttributeSlice.Add("7.20", "/container/envs", "name", "list")
     driftAttributeSlice.Add("7.20", "/interface/vxlan", "vrf", "vtep-vrf")
+    driftAttributeSlice.Add("7.21", "/ip/ssh", "always-allow-password-login", "password-authentication")
     driftAttributeSlice.SortDesc()
 }

--- a/routeros/mikrotik_resource_drift.yaml
+++ b/routeros/mikrotik_resource_drift.yaml
@@ -33,3 +33,7 @@
   /container/envs:
     - tf: name
       mt: list
+7.21:
+  /ip/ssh:
+    - tf: always-allow-password-login
+      mt: password-authentication


### PR DESCRIPTION
From 7.21 changelog:

*) ssh - replaced "always-allow-password-login" with "password-authentication" in SSH settings;