### PR TITLE
feat: opt-in bulk_read_refresh for order-of-magnitude faster refresh

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -62,6 +62,7 @@ resource "routeros_interface_gre" "gre_hq" {
 
 ### Optional
 
+- `bulk_read_refresh` (Boolean) When true, Terraform state refresh fetches each resource path in a single bulk GET and serves subsequent per-id reads from an in-memory cache invalidated on writes. Speeds up plans over large resource sets (e.g. thousands of DNS records) by an order of magnitude when most records on a path are managed by Terraform. Can slow down plans on configs that manage only a handful of records on a path populated by many unmanaged entries, because each bulk fetch returns the full path. Opt-in; default false preserves the traditional per-id filtered GET behavior (env: ROS_BULK_READ_REFRESH).
 - `ca_certificate` (String) Path to MikroTik's certificate authority file (env: ROS_CA_CERTIFICATE | MIKROTIK_CA_CERTIFICATE).
 - `insecure` (Boolean) Whether to verify the SSL certificate or not (env: ROS_INSECURE | MIKROTIK_INSECURE).
 - `password` (String, Sensitive) Password for the MikroTik user (env: ROS_PASSWORD | MIKROTIK_PASSWORD).

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0
 	github.com/sirupsen/logrus v1.9.4
 	github.com/sourcegraph/go-diff-patch v0.0.0-20240223163233-798fd1e94a8e
+	golang.org/x/sync v0.20.0
 )
 
 require (
@@ -30,7 +31,6 @@ require (
 	github.com/yuin/goldmark-meta v1.1.0 // indirect
 	go.abhg.dev/goldmark/frontmatter v0.2.0 // indirect
 	golang.org/x/exp v0.0.0-20230809150735-7b3493d9a819 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/term v0.41.0 // indirect
 	golang.org/x/tools v0.42.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect

--- a/routeros/bulk_read_cache.go
+++ b/routeros/bulk_read_cache.go
@@ -35,6 +35,9 @@ type BulkReadCache struct {
 // discarded. DoBulkFetch catches this sentinel internally and retries.
 var errStaleBulkFetch = errors.New("bulk read: cache invalidated during fetch")
 
+// maxBulkFetchAttempts bounds the stale-retry loop. Each retry requires a
+// distinct intervening Invalidate to race the fetch, so 8 is well above any
+// realistic write storm and keeps a pathological case from hanging.
 const maxBulkFetchAttempts = 8
 
 func NewBulkReadCache() *BulkReadCache {
@@ -86,7 +89,6 @@ func (c *BulkReadCache) Invalidate(path string) {
 	c.mu.Unlock()
 }
 
-// currentGen returns the path's current generation under read lock.
 func (c *BulkReadCache) currentGen(path string) uint64 {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/routeros/bulk_read_cache.go
+++ b/routeros/bulk_read_cache.go
@@ -98,7 +98,7 @@ func (c *BulkReadCache) currentGen(path string) uint64 {
 // discarded (errStaleBulkFetch) and the caller retries at the new generation;
 // writers therefore do not wait on a stale in-flight fetch.
 func (c *BulkReadCache) DoBulkFetch(path string, fetch func() ([]MikrotikItem, error)) ([]MikrotikItem, error) {
-	for attempt := 0; attempt < maxBulkFetchAttempts; attempt++ {
+	for range maxBulkFetchAttempts {
 		startGen := c.currentGen(path)
 		key := path + ":" + strconv.FormatUint(startGen, 10)
 		v, err, _ := c.group.Do(key, func() (any, error) {

--- a/routeros/bulk_read_cache.go
+++ b/routeros/bulk_read_cache.go
@@ -1,0 +1,80 @@
+package routeros
+
+import (
+	"sync"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// BulkReadCache stores one-shot bulk reads of a RouterOS resource path so that
+// subsequent per-id reads during the same provider operation are served from
+// memory instead of issuing individual filtered GETs.
+//
+// The cache is opt-in via the provider-level "bulk_read_refresh" attribute. It
+// is populated on the first ReadItems call for a path and invalidated on any
+// successful Create/Update/Delete that targets that path.
+type BulkReadCache struct {
+	mu    sync.RWMutex
+	items map[string]map[string]MikrotikItem
+
+	// group coalesces concurrent bulk fetches for the same path so that N
+	// parallel Read calls trigger exactly one network round-trip.
+	group singleflight.Group
+}
+
+func NewBulkReadCache() *BulkReadCache {
+	return &BulkReadCache{items: map[string]map[string]MikrotikItem{}}
+}
+
+// Lookup reports whether a bulk fetch for path has been done (pathCached) and,
+// if so, whether the given id is present (itemFound). A pathCached=false result
+// means the caller must trigger a bulk fetch via DoBulkFetch.
+func (c *BulkReadCache) Lookup(path, id string) (item MikrotikItem, itemFound bool, pathCached bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	bucket, ok := c.items[path]
+	if !ok {
+		return nil, false, false
+	}
+	item, itemFound = bucket[id]
+	return item, itemFound, true
+}
+
+// populate replaces the cache entry for path with the provided items, indexed
+// by their RouterOS .id. Items without a .id are skipped defensively.
+func (c *BulkReadCache) populate(path string, items []MikrotikItem) {
+	bucket := make(map[string]MikrotikItem, len(items))
+	for _, it := range items {
+		if id := it.GetID(Id); id != "" {
+			bucket[id] = it
+		}
+	}
+	c.mu.Lock()
+	c.items[path] = bucket
+	c.mu.Unlock()
+}
+
+// Invalidate drops the cache entry for path. Safe to call on unknown paths.
+func (c *BulkReadCache) Invalidate(path string) {
+	c.mu.Lock()
+	delete(c.items, path)
+	c.mu.Unlock()
+}
+
+// DoBulkFetch runs fetch at most once per concurrent burst of callers for the
+// same path (singleflight semantics). Used by ReadItems to avoid thundering-herd
+// bulk GETs during parallel refresh.
+func (c *BulkReadCache) DoBulkFetch(path string, fetch func() ([]MikrotikItem, error)) ([]MikrotikItem, error) {
+	v, err, _ := c.group.Do(path, func() (any, error) {
+		items, err := fetch()
+		if err != nil {
+			return nil, err
+		}
+		c.populate(path, items)
+		return items, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.([]MikrotikItem), nil
+}

--- a/routeros/bulk_read_cache.go
+++ b/routeros/bulk_read_cache.go
@@ -1,6 +1,8 @@
 package routeros
 
 import (
+	"errors"
+	"strconv"
 	"sync"
 
 	"golang.org/x/sync/singleflight"
@@ -13,17 +15,33 @@ import (
 // The cache is opt-in via the provider-level "bulk_read_refresh" attribute. It
 // is populated on the first ReadItems call for a path and invalidated on any
 // successful Create/Update/Delete that targets that path.
+//
+// Concurrency model: a per-path generation counter is bumped by Invalidate.
+// DoBulkFetch captures the generation at fetch-start and refuses to populate
+// if it changed mid-flight, so writes that race with a bulk fetch cannot
+// leave the cache holding a pre-write snapshot. Singleflight keys embed the
+// generation, so writers that bump the generation do not coalesce with an
+// already-in-flight stale fetch.
 type BulkReadCache struct {
 	mu    sync.RWMutex
 	items map[string]map[string]MikrotikItem
+	gen   map[string]uint64
 
-	// group coalesces concurrent bulk fetches for the same path so that N
-	// parallel Read calls trigger exactly one network round-trip.
 	group singleflight.Group
 }
 
+// errStaleBulkFetch signals that Invalidate ran while a bulk fetch was in
+// flight, so the fetched items predate the concurrent write and must be
+// discarded. DoBulkFetch catches this sentinel internally and retries.
+var errStaleBulkFetch = errors.New("bulk read: cache invalidated during fetch")
+
+const maxBulkFetchAttempts = 8
+
 func NewBulkReadCache() *BulkReadCache {
-	return &BulkReadCache{items: map[string]map[string]MikrotikItem{}}
+	return &BulkReadCache{
+		items: map[string]map[string]MikrotikItem{},
+		gen:   map[string]uint64{},
+	}
 }
 
 // Lookup reports whether a bulk fetch for path has been done (pathCached) and,
@@ -40,41 +58,66 @@ func (c *BulkReadCache) Lookup(path, id string) (item MikrotikItem, itemFound bo
 	return item, itemFound, true
 }
 
-// populate replaces the cache entry for path with the provided items, indexed
-// by their RouterOS .id. Items without a .id are skipped defensively.
-func (c *BulkReadCache) populate(path string, items []MikrotikItem) {
+// populateIfFresh replaces the cache entry for path only when the generation
+// observed at fetch-start still matches. Returns true on successful populate.
+func (c *BulkReadCache) populateIfFresh(path string, items []MikrotikItem, startGen uint64) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.gen[path] != startGen {
+		return false
+	}
 	bucket := make(map[string]MikrotikItem, len(items))
 	for _, it := range items {
 		if id := it.GetID(Id); id != "" {
 			bucket[id] = it
 		}
 	}
-	c.mu.Lock()
 	c.items[path] = bucket
-	c.mu.Unlock()
+	return true
 }
 
-// Invalidate drops the cache entry for path. Safe to call on unknown paths.
+// Invalidate drops the cache entry for path and bumps its generation so any
+// concurrently in-flight bulk fetch observes the change and refuses to populate
+// a stale snapshot. Safe to call on unknown paths.
 func (c *BulkReadCache) Invalidate(path string) {
 	c.mu.Lock()
 	delete(c.items, path)
+	c.gen[path]++
 	c.mu.Unlock()
 }
 
-// DoBulkFetch runs fetch at most once per concurrent burst of callers for the
-// same path (singleflight semantics). Used by ReadItems to avoid thundering-herd
-// bulk GETs during parallel refresh.
+// currentGen returns the path's current generation under read lock.
+func (c *BulkReadCache) currentGen(path string) uint64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.gen[path]
+}
+
+// DoBulkFetch runs fetch at most once per concurrent burst of callers at the
+// same generation. If Invalidate runs during the fetch, the snapshot is
+// discarded (errStaleBulkFetch) and the caller retries at the new generation;
+// writers therefore do not wait on a stale in-flight fetch.
 func (c *BulkReadCache) DoBulkFetch(path string, fetch func() ([]MikrotikItem, error)) ([]MikrotikItem, error) {
-	v, err, _ := c.group.Do(path, func() (any, error) {
-		items, err := fetch()
+	for attempt := 0; attempt < maxBulkFetchAttempts; attempt++ {
+		startGen := c.currentGen(path)
+		key := path + ":" + strconv.FormatUint(startGen, 10)
+		v, err, _ := c.group.Do(key, func() (any, error) {
+			items, err := fetch()
+			if err != nil {
+				return nil, err
+			}
+			if !c.populateIfFresh(path, items, startGen) {
+				return nil, errStaleBulkFetch
+			}
+			return items, nil
+		})
+		if errors.Is(err, errStaleBulkFetch) {
+			continue
+		}
 		if err != nil {
 			return nil, err
 		}
-		c.populate(path, items)
-		return items, nil
-	})
-	if err != nil {
-		return nil, err
+		return v.([]MikrotikItem), nil
 	}
-	return v.([]MikrotikItem), nil
+	return nil, errors.New("bulk read: cache repeatedly invalidated during fetch, aborting")
 }

--- a/routeros/bulk_read_cache_test.go
+++ b/routeros/bulk_read_cache_test.go
@@ -135,26 +135,19 @@ func TestBulkReadCache_DoBulkFetch_CoalescesConcurrentCallers(t *testing.T) {
 	}
 }
 
-// TestBulkReadCache_DoBulkFetch_InvalidateMidFetch_DiscardsStaleSnapshot
-// regression-guards the cache/invalidation race: if Invalidate runs while a
-// bulk fetch is in flight, the fetched (pre-invalidate) items must not be
-// committed to the cache, otherwise concurrent writers would later read a
-// snapshot that predates their own writes and see their new ids as missing.
+// A bulk fetch that returns after a concurrent Invalidate must not commit its
+// pre-write snapshot to the cache, or concurrent writers would later see their
+// new ids as missing.
 func TestBulkReadCache_DoBulkFetch_InvalidateMidFetch_DiscardsStaleSnapshot(t *testing.T) {
 	c := NewBulkReadCache()
 	const path = "/ip/dns/static"
 
-	// First fetch: starts, we Invalidate() before it returns, then it returns
-	// the stale snapshot. populateIfFresh must reject it; DoBulkFetch must
-	// observe errStaleBulkFetch internally and retry at the new generation.
 	var attempts atomic.Int64
 	items, err := c.DoBulkFetch(path, func() ([]MikrotikItem, error) {
 		if attempts.Add(1) == 1 {
-			// Simulate a concurrent writer bumping the generation mid-fetch.
 			c.Invalidate(path)
 			return []MikrotikItem{{".id": "*stale"}}, nil
 		}
-		// The retry observes the post-invalidate generation and fetches fresh.
 		return []MikrotikItem{{".id": "*fresh-1"}, {".id": "*fresh-2"}}, nil
 	})
 	if err != nil {
@@ -175,11 +168,8 @@ func TestBulkReadCache_DoBulkFetch_InvalidateMidFetch_DiscardsStaleSnapshot(t *t
 	}
 }
 
-// TestBulkReadCache_DoBulkFetch_ConcurrentInvalidateDoesNotStrand
-// exercises the worst case for singleflight coalescing: a bulk fetch is
-// in-flight when a writer invalidates and then reads its own new id. The
-// writer must not get the pre-write snapshot that the in-flight fetch would
-// otherwise produce.
+// Writer must not get the in-flight reader's pre-write snapshot via singleflight
+// coalescing: its post-Invalidate DoBulkFetch must trigger a fresh fetch.
 func TestBulkReadCache_DoBulkFetch_ConcurrentInvalidateDoesNotStrand(t *testing.T) {
 	c := NewBulkReadCache()
 	const path = "/ip/dns/static"

--- a/routeros/bulk_read_cache_test.go
+++ b/routeros/bulk_read_cache_test.go
@@ -22,9 +22,18 @@ func TestBulkReadCache_Lookup_EmptyCache(t *testing.T) {
 	}
 }
 
+// primeCache populates the cache via a synchronous DoBulkFetch so tests can
+// set up cache state without duplicating the production populate path.
+func primeCache(t *testing.T, c *BulkReadCache, path string, items []MikrotikItem) {
+	t.Helper()
+	if _, err := c.DoBulkFetch(path, func() ([]MikrotikItem, error) { return items, nil }); err != nil {
+		t.Fatalf("primeCache: %v", err)
+	}
+}
+
 func TestBulkReadCache_PopulateAndLookup_Hit(t *testing.T) {
 	c := NewBulkReadCache()
-	c.populate("/ip/dns/static", []MikrotikItem{
+	primeCache(t, c, "/ip/dns/static", []MikrotikItem{
 		{".id": "*1", "name": "alpha"},
 		{".id": "*2", "name": "beta"},
 	})
@@ -42,7 +51,7 @@ func TestBulkReadCache_PopulateAndLookup_Hit(t *testing.T) {
 
 func TestBulkReadCache_PopulateAndLookup_MissOnKnownPath(t *testing.T) {
 	c := NewBulkReadCache()
-	c.populate("/ip/dns/static", []MikrotikItem{{".id": "*1"}})
+	primeCache(t, c, "/ip/dns/static", []MikrotikItem{{".id": "*1"}})
 	item, itemFound, pathCached := c.Lookup("/ip/dns/static", "*999")
 	if !pathCached {
 		t.Errorf("pathCached = false, want true (path was populated)")
@@ -57,7 +66,7 @@ func TestBulkReadCache_PopulateAndLookup_MissOnKnownPath(t *testing.T) {
 
 func TestBulkReadCache_Invalidate(t *testing.T) {
 	c := NewBulkReadCache()
-	c.populate("/ip/dns/static", []MikrotikItem{{".id": "*1"}})
+	primeCache(t, c, "/ip/dns/static", []MikrotikItem{{".id": "*1"}})
 	c.Invalidate("/ip/dns/static")
 	_, _, pathCached := c.Lookup("/ip/dns/static", "*1")
 	if pathCached {
@@ -127,6 +136,121 @@ func TestBulkReadCache_DoBulkFetch_CoalescesConcurrentCallers(t *testing.T) {
 	}
 	if _, found, _ := c.Lookup("/ip/dns/static", "*1"); !found {
 		t.Errorf("cache was not populated after DoBulkFetch")
+	}
+}
+
+// TestBulkReadCache_DoBulkFetch_InvalidateMidFetch_DiscardsStaleSnapshot
+// regression-guards the cache/invalidation race: if Invalidate runs while a
+// bulk fetch is in flight, the fetched (pre-invalidate) items must not be
+// committed to the cache, otherwise concurrent writers would later read a
+// snapshot that predates their own writes and see their new ids as missing.
+func TestBulkReadCache_DoBulkFetch_InvalidateMidFetch_DiscardsStaleSnapshot(t *testing.T) {
+	c := NewBulkReadCache()
+	const path = "/ip/dns/static"
+
+	// First fetch: starts, we Invalidate() before it returns, then it returns
+	// the stale snapshot. populateIfFresh must reject it; DoBulkFetch must
+	// observe errStaleBulkFetch internally and retry at the new generation.
+	var attempts int64
+	items, err := c.DoBulkFetch(path, func() ([]MikrotikItem, error) {
+		n := atomic.AddInt64(&attempts, 1)
+		if n == 1 {
+			// Simulate a concurrent writer bumping the generation mid-fetch.
+			c.Invalidate(path)
+			return []MikrotikItem{{".id": "*stale"}}, nil
+		}
+		// The retry observes the post-invalidate generation and fetches fresh.
+		return []MikrotikItem{{".id": "*fresh-1"}, {".id": "*fresh-2"}}, nil
+	})
+	if err != nil {
+		t.Fatalf("DoBulkFetch err = %v", err)
+	}
+	if atomic.LoadInt64(&attempts) != 2 {
+		t.Errorf("fetch attempts = %d, want 2 (first stale, retry fresh)", attempts)
+	}
+	if len(items) != 2 || items[0][".id"] != "*fresh-1" {
+		t.Errorf("items = %v, want the fresh post-invalidate snapshot", items)
+	}
+	// Cache must hold only the fresh items; the stale *stale id must not leak.
+	if _, found, _ := c.Lookup(path, "*stale"); found {
+		t.Errorf("cache holds stale *stale — populate ran despite Invalidate")
+	}
+	if _, found, _ := c.Lookup(path, "*fresh-1"); !found {
+		t.Errorf("cache missing *fresh-1 — retry did not populate")
+	}
+}
+
+// TestBulkReadCache_DoBulkFetch_ConcurrentInvalidateDoesNotStrand
+// exercises the worst case for singleflight coalescing: a bulk fetch is
+// in-flight when a writer invalidates and then reads its own new id. The
+// writer must not get the pre-write snapshot that the in-flight fetch would
+// otherwise produce.
+func TestBulkReadCache_DoBulkFetch_ConcurrentInvalidateDoesNotStrand(t *testing.T) {
+	c := NewBulkReadCache()
+	const path = "/ip/dns/static"
+
+	release := make(chan struct{})
+	firstStarted := make(chan struct{})
+	var once sync.Once
+	var attempts int64
+
+	fetch := func() ([]MikrotikItem, error) {
+		n := atomic.AddInt64(&attempts, 1)
+		if n == 1 {
+			once.Do(func() { close(firstStarted) })
+			<-release // block first fetch until the writer arrives
+			return []MikrotikItem{{".id": "*old"}}, nil
+		}
+		return []MikrotikItem{{".id": "*old"}, {".id": "*new"}}, nil
+	}
+
+	var readerItems []MikrotikItem
+	var readerErr error
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		readerItems, readerErr = c.DoBulkFetch(path, fetch)
+	}()
+
+	<-firstStarted
+	// Writer invalidates (as a real CreateItem would after a successful write)
+	// then issues its post-write read. This must not be served the pre-write
+	// snapshot from the in-flight reader's fetch.
+	c.Invalidate(path)
+	var writerItems []MikrotikItem
+	var writerErr error
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		writerItems, writerErr = c.DoBulkFetch(path, fetch)
+	}()
+
+	// Give the writer time to enter DoBulkFetch and pick its generation before
+	// we unblock the original (stale) fetch.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+
+	<-readerDone
+	<-writerDone
+
+	if readerErr != nil {
+		t.Fatalf("reader err = %v", readerErr)
+	}
+	if writerErr != nil {
+		t.Fatalf("writer err = %v", writerErr)
+	}
+	// Both callers must ultimately see the post-invalidate snapshot that
+	// contains *new. The writer would silently miss its own resource otherwise.
+	for _, items := range [][]MikrotikItem{readerItems, writerItems} {
+		var sawNew bool
+		for _, it := range items {
+			if it[".id"] == "*new" {
+				sawNew = true
+			}
+		}
+		if !sawNew {
+			t.Errorf("got %v, want a snapshot containing *new (post-invalidate state)", items)
+		}
 	}
 }
 

--- a/routeros/bulk_read_cache_test.go
+++ b/routeros/bulk_read_cache_test.go
@@ -1,0 +1,143 @@
+package routeros
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestBulkReadCache_Lookup_EmptyCache(t *testing.T) {
+	c := NewBulkReadCache()
+	item, itemFound, pathCached := c.Lookup("/ip/dns/static", "*1")
+	if pathCached {
+		t.Errorf("pathCached = true, want false for empty cache")
+	}
+	if itemFound {
+		t.Errorf("itemFound = true, want false for empty cache")
+	}
+	if item != nil {
+		t.Errorf("item = %v, want nil", item)
+	}
+}
+
+func TestBulkReadCache_PopulateAndLookup_Hit(t *testing.T) {
+	c := NewBulkReadCache()
+	c.populate("/ip/dns/static", []MikrotikItem{
+		{".id": "*1", "name": "alpha"},
+		{".id": "*2", "name": "beta"},
+	})
+	item, itemFound, pathCached := c.Lookup("/ip/dns/static", "*2")
+	if !pathCached {
+		t.Errorf("pathCached = false, want true")
+	}
+	if !itemFound {
+		t.Errorf("itemFound = false, want true")
+	}
+	if item["name"] != "beta" {
+		t.Errorf("item[name] = %v, want beta", item["name"])
+	}
+}
+
+func TestBulkReadCache_PopulateAndLookup_MissOnKnownPath(t *testing.T) {
+	c := NewBulkReadCache()
+	c.populate("/ip/dns/static", []MikrotikItem{{".id": "*1"}})
+	item, itemFound, pathCached := c.Lookup("/ip/dns/static", "*999")
+	if !pathCached {
+		t.Errorf("pathCached = false, want true (path was populated)")
+	}
+	if itemFound {
+		t.Errorf("itemFound = true, want false (id not in bulk response)")
+	}
+	if item != nil {
+		t.Errorf("item = %v, want nil", item)
+	}
+}
+
+func TestBulkReadCache_Invalidate(t *testing.T) {
+	c := NewBulkReadCache()
+	c.populate("/ip/dns/static", []MikrotikItem{{".id": "*1"}})
+	c.Invalidate("/ip/dns/static")
+	_, _, pathCached := c.Lookup("/ip/dns/static", "*1")
+	if pathCached {
+		t.Errorf("pathCached = true after Invalidate, want false")
+	}
+}
+
+func TestBulkReadCache_DoBulkFetch_CoalescesConcurrentCallers(t *testing.T) {
+	c := NewBulkReadCache()
+	const workers = 50
+	var fetchCount int64
+	response := []MikrotikItem{{".id": "*1", "name": "only"}}
+
+	fetchStarted := make(chan struct{})
+	release := make(chan struct{})
+	fetch := func() ([]MikrotikItem, error) {
+		atomic.AddInt64(&fetchCount, 1)
+		close(fetchStarted)
+		<-release
+		return response, nil
+	}
+
+	var wg sync.WaitGroup
+	results := make([]MikrotikItem, workers)
+
+	// Worker 0 starts the fetch and blocks inside it.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		items, err := c.DoBulkFetch("/ip/dns/static", fetch)
+		if err != nil {
+			t.Errorf("worker 0: %v", err)
+			return
+		}
+		results[0] = items[0]
+	}()
+
+	<-fetchStarted
+
+	wg.Add(workers - 1)
+	for i := 1; i < workers; i++ {
+		go func(i int) {
+			defer wg.Done()
+			items, err := c.DoBulkFetch("/ip/dns/static", fetch)
+			if err != nil {
+				t.Errorf("worker %d: %v", i, err)
+				return
+			}
+			results[i] = items[0]
+		}(i)
+	}
+
+	// Give the late workers time to enter DoBulkFetch before we release.
+	// The singleflight group only coalesces callers that arrive while the
+	// in-flight call is still running.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	if got := atomic.LoadInt64(&fetchCount); got != 1 {
+		t.Errorf("fetch invoked %d times, want 1 (singleflight must coalesce)", got)
+	}
+	for i, item := range results {
+		if item["name"] != "only" {
+			t.Errorf("worker %d got %v, want {name:only}", i, item)
+		}
+	}
+	if _, found, _ := c.Lookup("/ip/dns/static", "*1"); !found {
+		t.Errorf("cache was not populated after DoBulkFetch")
+	}
+}
+
+func TestBulkReadCache_DoBulkFetch_ErrorDoesNotPopulate(t *testing.T) {
+	c := NewBulkReadCache()
+	wantErr := fmt.Errorf("network boom")
+	_, err := c.DoBulkFetch("/p", func() ([]MikrotikItem, error) { return nil, wantErr })
+	if err != wantErr {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+	if _, _, pathCached := c.Lookup("/p", "*1"); pathCached {
+		t.Errorf("cache was populated after failed fetch")
+	}
+}

--- a/routeros/bulk_read_cache_test.go
+++ b/routeros/bulk_read_cache_test.go
@@ -77,13 +77,13 @@ func TestBulkReadCache_Invalidate(t *testing.T) {
 func TestBulkReadCache_DoBulkFetch_CoalescesConcurrentCallers(t *testing.T) {
 	c := NewBulkReadCache()
 	const workers = 50
-	var fetchCount int64
+	var fetchCount atomic.Int64
 	response := []MikrotikItem{{".id": "*1", "name": "only"}}
 
 	fetchStarted := make(chan struct{})
 	release := make(chan struct{})
 	fetch := func() ([]MikrotikItem, error) {
-		atomic.AddInt64(&fetchCount, 1)
+		fetchCount.Add(1)
 		close(fetchStarted)
 		<-release
 		return response, nil
@@ -93,30 +93,26 @@ func TestBulkReadCache_DoBulkFetch_CoalescesConcurrentCallers(t *testing.T) {
 	results := make([]MikrotikItem, workers)
 
 	// Worker 0 starts the fetch and blocks inside it.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		items, err := c.DoBulkFetch("/ip/dns/static", fetch)
 		if err != nil {
 			t.Errorf("worker 0: %v", err)
 			return
 		}
 		results[0] = items[0]
-	}()
+	})
 
 	<-fetchStarted
 
-	wg.Add(workers - 1)
 	for i := 1; i < workers; i++ {
-		go func(i int) {
-			defer wg.Done()
+		wg.Go(func() {
 			items, err := c.DoBulkFetch("/ip/dns/static", fetch)
 			if err != nil {
 				t.Errorf("worker %d: %v", i, err)
 				return
 			}
 			results[i] = items[0]
-		}(i)
+		})
 	}
 
 	// Give the late workers time to enter DoBulkFetch before we release.
@@ -126,7 +122,7 @@ func TestBulkReadCache_DoBulkFetch_CoalescesConcurrentCallers(t *testing.T) {
 	close(release)
 	wg.Wait()
 
-	if got := atomic.LoadInt64(&fetchCount); got != 1 {
+	if got := fetchCount.Load(); got != 1 {
 		t.Errorf("fetch invoked %d times, want 1 (singleflight must coalesce)", got)
 	}
 	for i, item := range results {
@@ -151,10 +147,9 @@ func TestBulkReadCache_DoBulkFetch_InvalidateMidFetch_DiscardsStaleSnapshot(t *t
 	// First fetch: starts, we Invalidate() before it returns, then it returns
 	// the stale snapshot. populateIfFresh must reject it; DoBulkFetch must
 	// observe errStaleBulkFetch internally and retry at the new generation.
-	var attempts int64
+	var attempts atomic.Int64
 	items, err := c.DoBulkFetch(path, func() ([]MikrotikItem, error) {
-		n := atomic.AddInt64(&attempts, 1)
-		if n == 1 {
+		if attempts.Add(1) == 1 {
 			// Simulate a concurrent writer bumping the generation mid-fetch.
 			c.Invalidate(path)
 			return []MikrotikItem{{".id": "*stale"}}, nil
@@ -165,8 +160,8 @@ func TestBulkReadCache_DoBulkFetch_InvalidateMidFetch_DiscardsStaleSnapshot(t *t
 	if err != nil {
 		t.Fatalf("DoBulkFetch err = %v", err)
 	}
-	if atomic.LoadInt64(&attempts) != 2 {
-		t.Errorf("fetch attempts = %d, want 2 (first stale, retry fresh)", attempts)
+	if got := attempts.Load(); got != 2 {
+		t.Errorf("fetch attempts = %d, want 2 (first stale, retry fresh)", got)
 	}
 	if len(items) != 2 || items[0][".id"] != "*fresh-1" {
 		t.Errorf("items = %v, want the fresh post-invalidate snapshot", items)
@@ -191,47 +186,39 @@ func TestBulkReadCache_DoBulkFetch_ConcurrentInvalidateDoesNotStrand(t *testing.
 
 	release := make(chan struct{})
 	firstStarted := make(chan struct{})
-	var once sync.Once
-	var attempts int64
+	var attempts atomic.Int64
 
 	fetch := func() ([]MikrotikItem, error) {
-		n := atomic.AddInt64(&attempts, 1)
-		if n == 1 {
-			once.Do(func() { close(firstStarted) })
+		if attempts.Add(1) == 1 {
+			close(firstStarted)
 			<-release // block first fetch until the writer arrives
 			return []MikrotikItem{{".id": "*old"}}, nil
 		}
 		return []MikrotikItem{{".id": "*old"}, {".id": "*new"}}, nil
 	}
 
-	var readerItems []MikrotikItem
-	var readerErr error
-	readerDone := make(chan struct{})
-	go func() {
-		defer close(readerDone)
+	var wg sync.WaitGroup
+	var readerItems, writerItems []MikrotikItem
+	var readerErr, writerErr error
+
+	wg.Go(func() {
 		readerItems, readerErr = c.DoBulkFetch(path, fetch)
-	}()
+	})
 
 	<-firstStarted
 	// Writer invalidates (as a real CreateItem would after a successful write)
 	// then issues its post-write read. This must not be served the pre-write
 	// snapshot from the in-flight reader's fetch.
 	c.Invalidate(path)
-	var writerItems []MikrotikItem
-	var writerErr error
-	writerDone := make(chan struct{})
-	go func() {
-		defer close(writerDone)
+	wg.Go(func() {
 		writerItems, writerErr = c.DoBulkFetch(path, fetch)
-	}()
+	})
 
 	// Give the writer time to enter DoBulkFetch and pick its generation before
 	// we unblock the original (stale) fetch.
 	time.Sleep(50 * time.Millisecond)
 	close(release)
-
-	<-readerDone
-	<-writerDone
+	wg.Wait()
 
 	if readerErr != nil {
 		t.Fatalf("reader err = %v", readerErr)

--- a/routeros/mikrotik_client.go
+++ b/routeros/mikrotik_client.go
@@ -21,6 +21,9 @@ type Client interface {
 	GetExtraParams() *ExtraParams
 	GetTransport() TransportType
 	SendRequest(method crudMethod, url *URL, item MikrotikItem, result interface{}) error
+	// GetBulkCache returns the opt-in per-path read cache or nil when the
+	// "bulk_read_refresh" provider attribute is disabled.
+	GetBulkCache() *BulkReadCache
 }
 
 type crudMethod int
@@ -119,6 +122,11 @@ func NewClient(ctx context.Context, d *schema.ResourceData) (interface{}, diag.D
 		ColorizedMessage(ctx, INFO, "RouterOS from env: "+RouterOSVersion)
 	}
 
+	var cache *BulkReadCache
+	if d.Get("bulk_read_refresh").(bool) {
+		cache = NewBulkReadCache()
+	}
+
 	if transport == TransportAPI {
 		api := &ApiClient{
 			ctx:       ctx,
@@ -129,6 +137,7 @@ func NewClient(ctx context.Context, d *schema.ResourceData) (interface{}, diag.D
 			extra: &ExtraParams{
 				SuppressSysODelWarn: d.Get("suppress_syso_del_warn").(bool),
 			},
+			bulkCache: cache,
 		}
 
 		if useTLS {
@@ -166,6 +175,7 @@ func NewClient(ctx context.Context, d *schema.ResourceData) (interface{}, diag.D
 		extra: &ExtraParams{
 			SuppressSysODelWarn: d.Get("suppress_syso_del_warn").(bool),
 		},
+		bulkCache: cache,
 	}
 
 	rest.Client = &http.Client{

--- a/routeros/mikrotik_client_api.go
+++ b/routeros/mikrotik_client_api.go
@@ -16,6 +16,7 @@ type ApiClient struct {
 	Password  string
 	Transport TransportType
 	extra     *ExtraParams
+	bulkCache *BulkReadCache
 	*routeros.Client
 }
 
@@ -44,6 +45,10 @@ func (c *ApiClient) GetExtraParams() *ExtraParams {
 
 func (c *ApiClient) GetTransport() TransportType {
 	return c.Transport
+}
+
+func (c *ApiClient) GetBulkCache() *BulkReadCache {
+	return c.bulkCache
 }
 
 func (c *ApiClient) SendRequest(method crudMethod, url *URL, item MikrotikItem, result interface{}) error {

--- a/routeros/mikrotik_client_rest.go
+++ b/routeros/mikrotik_client_rest.go
@@ -18,6 +18,7 @@ type RestClient struct {
 	Password  string
 	Transport TransportType
 	extra     *ExtraParams
+	bulkCache *BulkReadCache
 	*http.Client
 }
 
@@ -52,6 +53,10 @@ func (c *RestClient) GetExtraParams() *ExtraParams {
 
 func (c *RestClient) GetTransport() TransportType {
 	return c.Transport
+}
+
+func (c *RestClient) GetBulkCache() *BulkReadCache {
+	return c.bulkCache
 }
 
 func (c *RestClient) SendRequest(method crudMethod, url *URL, item MikrotikItem, result interface{}) error {

--- a/routeros/mikrotik_crud.go
+++ b/routeros/mikrotik_crud.go
@@ -24,6 +24,7 @@ func CreateItem(ctx context.Context, item MikrotikItem, resourcePath string, c C
 	}
 
 	var crud = crudCreate
+	invalidationPath := resourcePath
 
 	if cm := ctxGetCrudMethod(ctx); cm != crudUnknown {
 		crud = cm
@@ -35,6 +36,11 @@ func CreateItem(ctx context.Context, item MikrotikItem, resourcePath string, c C
 
 	res := MikrotikItem{}
 	err := c.SendRequest(crud, &URL{Path: resourcePath}, item, &res)
+	if err == nil {
+		if cache := c.GetBulkCache(); cache != nil {
+			cache.Invalidate(invalidationPath)
+		}
+	}
 
 	return res, err
 }
@@ -44,6 +50,37 @@ func ReadItems(id *ItemId, resourcePath string, c Client) (*[]MikrotikItem, erro
 
 	if resourcePath == "" {
 		return nil, errEmptyPath
+	}
+
+	// Bulk-read cache fast path. Only kicks in for .id lookups on a managed
+	// resource when the provider has "bulk_read_refresh" enabled. Datasource
+	// reads (id==nil) and name-based lookups fall through to the original
+	// filtered GET so their semantics are unchanged.
+	if id != nil && id.Type == Id {
+		if cache := c.GetBulkCache(); cache != nil {
+			if item, itemFound, pathCached := cache.Lookup(resourcePath, id.Value); pathCached {
+				if itemFound {
+					return &[]MikrotikItem{item}, nil
+				}
+				return &[]MikrotikItem{}, nil
+			}
+			all, err := cache.DoBulkFetch(resourcePath, func() ([]MikrotikItem, error) {
+				var items []MikrotikItem
+				if err := c.SendRequest(crudRead, &URL{Path: resourcePath}, nil, &items); err != nil {
+					return nil, err
+				}
+				return items, nil
+			})
+			if err != nil {
+				return nil, err
+			}
+			for _, it := range all {
+				if it.GetID(Id) == id.Value {
+					return &[]MikrotikItem{it}, nil
+				}
+			}
+			return &[]MikrotikItem{}, nil
+		}
 	}
 
 	url := &URL{Path: resourcePath}
@@ -93,6 +130,8 @@ func UpdateItem(id *ItemId, resourcePath string, item MikrotikItem, c Client) (M
 		return nil, errEmptyPath
 	}
 
+	invalidationPath := resourcePath
+
 	if c.GetTransport() == TransportREST {
 		// /interface/vlan/*39
 		resourcePath += "/" + id.Value
@@ -102,6 +141,11 @@ func UpdateItem(id *ItemId, resourcePath string, item MikrotikItem, c Client) (M
 
 	res := MikrotikItem{}
 	err := c.SendRequest(crudUpdate, &URL{Path: resourcePath}, item, &res)
+	if err == nil {
+		if cache := c.GetBulkCache(); cache != nil {
+			cache.Invalidate(invalidationPath)
+		}
+	}
 
 	return res, err
 }
@@ -114,6 +158,7 @@ func DeleteItem(id *ItemId, resourcePath string, c Client) error {
 		return errEmptyPath
 	}
 
+	invalidationPath := resourcePath
 	url := &URL{Path: resourcePath}
 
 	if c.GetTransport() == TransportREST {
@@ -127,5 +172,11 @@ func DeleteItem(id *ItemId, resourcePath string, c Client) error {
 		url.Query = []string{"=.id=" + id.Value}
 	}
 
-	return c.SendRequest(crudDelete, url, nil, &MikrotikItem{})
+	err := c.SendRequest(crudDelete, url, nil, &MikrotikItem{})
+	if err == nil {
+		if cache := c.GetBulkCache(); cache != nil {
+			cache.Invalidate(invalidationPath)
+		}
+	}
+	return err
 }

--- a/routeros/mikrotik_crud.go
+++ b/routeros/mikrotik_crud.go
@@ -52,10 +52,7 @@ func ReadItems(id *ItemId, resourcePath string, c Client) (*[]MikrotikItem, erro
 		return nil, errEmptyPath
 	}
 
-	// Bulk-read cache fast path. Only kicks in for .id lookups on a managed
-	// resource when the provider has "bulk_read_refresh" enabled. Datasource
-	// reads (id==nil) and name-based lookups fall through to the original
-	// filtered GET so their semantics are unchanged.
+	// Datasource reads (id==nil) and name-type lookups keep original semantics.
 	if id != nil && id.Type == Id {
 		if cache := c.GetBulkCache(); cache != nil {
 			if item, itemFound, pathCached := cache.Lookup(resourcePath, id.Value); pathCached {
@@ -158,7 +155,6 @@ func DeleteItem(id *ItemId, resourcePath string, c Client) error {
 		return errEmptyPath
 	}
 
-	invalidationPath := resourcePath
 	url := &URL{Path: resourcePath}
 
 	if c.GetTransport() == TransportREST {
@@ -175,7 +171,7 @@ func DeleteItem(id *ItemId, resourcePath string, c Client) error {
 	err := c.SendRequest(crudDelete, url, nil, &MikrotikItem{})
 	if err == nil {
 		if cache := c.GetBulkCache(); cache != nil {
-			cache.Invalidate(invalidationPath)
+			cache.Invalidate(resourcePath)
 		}
 	}
 	return err

--- a/routeros/mikrotik_crud_bulk_read_test.go
+++ b/routeros/mikrotik_crud_bulk_read_test.go
@@ -269,10 +269,8 @@ func TestReadItems_CacheEnabled_ParallelCallsCoalesceToOneBulkGet(t *testing.T) 
 	// count, which is what the feature promises.
 	const workers = 100
 	var wg sync.WaitGroup
-	wg.Add(workers)
-	for i := 0; i < workers; i++ {
-		go func(i int) {
-			defer wg.Done()
+	for i := range workers {
+		wg.Go(func() {
 			id := fmt.Sprintf("*%d", i)
 			res, err := ReadItems(&ItemId{Id, id}, "/ip/dns/static", fc)
 			if err != nil {
@@ -282,7 +280,7 @@ func TestReadItems_CacheEnabled_ParallelCallsCoalesceToOneBulkGet(t *testing.T) 
 			if len(*res) != 1 || (*res)[0]["seq"] != fmt.Sprintf("%d", i) {
 				t.Errorf("worker %d got %v", i, *res)
 			}
-		}(i)
+		})
 	}
 	wg.Wait()
 

--- a/routeros/mikrotik_crud_bulk_read_test.go
+++ b/routeros/mikrotik_crud_bulk_read_test.go
@@ -263,10 +263,9 @@ func TestReadItems_CacheEnabled_ParallelCallsCoalesceToOneBulkGet(t *testing.T) 
 	}
 	fc.bulkItems["/ip/dns/static"] = items
 
-	// The fake's SendRequest is fast so singleflight may not coalesce every
-	// call — caching correctness is the real contract. We assert the weaker
-	// invariant that the number of bulk GETs is bounded far below the worker
-	// count, which is what the feature promises.
+	// The in-memory fake is too fast for singleflight to coalesce every call, so
+	// we assert the weaker invariant the feature actually promises: bulk GETs
+	// are bounded far below the worker count.
 	const workers = 100
 	var wg sync.WaitGroup
 	for i := range workers {
@@ -284,9 +283,6 @@ func TestReadItems_CacheEnabled_ParallelCallsCoalesceToOneBulkGet(t *testing.T) 
 	}
 	wg.Wait()
 
-	// With a fast in-memory fake, singleflight may not coalesce every single
-	// call — but the number of bulk GETs must be small and bounded (far less
-	// than one per worker). Caching correctness is the real contract.
 	got := fc.bulkReadCount("/ip/dns/static")
 	if got >= workers {
 		t.Errorf("bulk GET calls = %d, want far fewer than %d (cache must amortize)", got, workers)

--- a/routeros/mikrotik_crud_bulk_read_test.go
+++ b/routeros/mikrotik_crud_bulk_read_test.go
@@ -1,0 +1,343 @@
+package routeros
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// recordedCall captures a single SendRequest invocation so tests can assert on
+// what network traffic the provider would have issued.
+type recordedCall struct {
+	method crudMethod
+	path   string
+	query  []string
+}
+
+// fakeClient is an in-memory Client implementation used for unit-testing the
+// CRUD plumbing without touching a real router.
+type fakeClient struct {
+	mu        sync.Mutex
+	calls     []recordedCall
+	bulkItems map[string][]MikrotikItem // path -> canned response for bulk GET
+	filtered  map[string]MikrotikItem   // path + query-key -> canned response for filtered GET
+	sendErr   error                     // if set, SendRequest returns this error
+	cache     *BulkReadCache
+	transport TransportType
+}
+
+func newFakeClient(enableCache bool) *fakeClient {
+	fc := &fakeClient{
+		bulkItems: map[string][]MikrotikItem{},
+		filtered:  map[string]MikrotikItem{},
+		transport: TransportREST,
+	}
+	if enableCache {
+		fc.cache = NewBulkReadCache()
+	}
+	return fc
+}
+
+func (f *fakeClient) GetExtraParams() *ExtraParams   { return &ExtraParams{} }
+func (f *fakeClient) GetTransport() TransportType    { return f.transport }
+func (f *fakeClient) GetBulkCache() *BulkReadCache   { return f.cache }
+
+func (f *fakeClient) SendRequest(method crudMethod, url *URL, item MikrotikItem, result interface{}) error {
+	f.mu.Lock()
+	f.calls = append(f.calls, recordedCall{method: method, path: url.Path, query: append([]string(nil), url.Query...)})
+	f.mu.Unlock()
+
+	if f.sendErr != nil {
+		return f.sendErr
+	}
+	if method != crudRead || result == nil {
+		return nil
+	}
+
+	slice, ok := result.(*[]MikrotikItem)
+	if !ok {
+		return nil
+	}
+
+	// Bulk GET has no query.
+	if len(url.Query) == 0 {
+		if items, found := f.bulkItems[url.Path]; found {
+			*slice = append(*slice, items...)
+		}
+		return nil
+	}
+
+	// Filtered GET ("?.id=*X"): return a single match if present.
+	key := url.Path + "|" + strings.Join(url.Query, "&")
+	if item, found := f.filtered[key]; found {
+		*slice = append(*slice, item)
+	}
+	return nil
+}
+
+func (f *fakeClient) callCount(method crudMethod, path string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := 0
+	for _, c := range f.calls {
+		if c.method == method && c.path == path {
+			n++
+		}
+	}
+	return n
+}
+
+func (f *fakeClient) bulkReadCount(path string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := 0
+	for _, c := range f.calls {
+		if c.method == crudRead && c.path == path && len(c.query) == 0 {
+			n++
+		}
+	}
+	return n
+}
+
+func (f *fakeClient) filteredReadCount(path string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	n := 0
+	for _, c := range f.calls {
+		if c.method == crudRead && c.path == path && len(c.query) > 0 {
+			n++
+		}
+	}
+	return n
+}
+
+// ---------- ReadItems tests ----------
+
+func TestReadItems_CacheDisabled_UsesFilteredGet(t *testing.T) {
+	fc := newFakeClient(false)
+	fc.filtered["/ip/dns/static|?.id=*1"] = MikrotikItem{".id": "*1", "name": "a"}
+
+	res, err := ReadItems(&ItemId{Id, "*1"}, "/ip/dns/static", fc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(*res) != 1 || (*res)[0]["name"] != "a" {
+		t.Errorf("got %v, want one item named a", *res)
+	}
+	if got := fc.filteredReadCount("/ip/dns/static"); got != 1 {
+		t.Errorf("filtered GET calls = %d, want 1", got)
+	}
+	if got := fc.bulkReadCount("/ip/dns/static"); got != 0 {
+		t.Errorf("bulk GET calls = %d, want 0 when cache disabled", got)
+	}
+}
+
+func TestReadItems_CacheEnabled_FirstCall_BulkGet(t *testing.T) {
+	fc := newFakeClient(true)
+	fc.bulkItems["/ip/dns/static"] = []MikrotikItem{
+		{".id": "*1", "name": "a"}, {".id": "*2", "name": "b"},
+	}
+
+	res, err := ReadItems(&ItemId{Id, "*1"}, "/ip/dns/static", fc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(*res) != 1 || (*res)[0]["name"] != "a" {
+		t.Errorf("got %v, want one item named a", *res)
+	}
+	if got := fc.bulkReadCount("/ip/dns/static"); got != 1 {
+		t.Errorf("bulk GET calls = %d, want 1", got)
+	}
+	if got := fc.filteredReadCount("/ip/dns/static"); got != 0 {
+		t.Errorf("filtered GET calls = %d, want 0", got)
+	}
+}
+
+func TestReadItems_CacheEnabled_SecondCall_NoRequest(t *testing.T) {
+	fc := newFakeClient(true)
+	fc.bulkItems["/ip/dns/static"] = []MikrotikItem{
+		{".id": "*1", "name": "a"}, {".id": "*2", "name": "b"},
+	}
+
+	if _, err := ReadItems(&ItemId{Id, "*1"}, "/ip/dns/static", fc); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadItems(&ItemId{Id, "*2"}, "/ip/dns/static", fc); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := fc.bulkReadCount("/ip/dns/static"); got != 1 {
+		t.Errorf("bulk GET calls = %d, want 1 (second Read must hit cache)", got)
+	}
+}
+
+func TestReadItems_CacheEnabled_IdNotInBulk_ReturnsEmpty(t *testing.T) {
+	fc := newFakeClient(true)
+	fc.bulkItems["/ip/dns/static"] = []MikrotikItem{{".id": "*1"}}
+
+	res, err := ReadItems(&ItemId{Id, "*missing"}, "/ip/dns/static", fc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(*res) != 0 {
+		t.Errorf("got %v, want empty slice", *res)
+	}
+
+	// Second lookup for the same missing id still serves from cache.
+	if _, err := ReadItems(&ItemId{Id, "*missing"}, "/ip/dns/static", fc); err != nil {
+		t.Fatal(err)
+	}
+	if got := fc.bulkReadCount("/ip/dns/static"); got != 1 {
+		t.Errorf("bulk GET calls = %d, want 1", got)
+	}
+}
+
+func TestReadItems_CacheEnabled_AfterInvalidate_RefetchesBulk(t *testing.T) {
+	fc := newFakeClient(true)
+	fc.bulkItems["/ip/dns/static"] = []MikrotikItem{{".id": "*1"}}
+
+	if _, err := ReadItems(&ItemId{Id, "*1"}, "/ip/dns/static", fc); err != nil {
+		t.Fatal(err)
+	}
+	fc.cache.Invalidate("/ip/dns/static")
+	if _, err := ReadItems(&ItemId{Id, "*1"}, "/ip/dns/static", fc); err != nil {
+		t.Fatal(err)
+	}
+	if got := fc.bulkReadCount("/ip/dns/static"); got != 2 {
+		t.Errorf("bulk GET calls = %d, want 2 (one per pre/post invalidate lookup)", got)
+	}
+}
+
+func TestReadItems_CacheEnabled_NilId_BypassesCache(t *testing.T) {
+	fc := newFakeClient(true)
+	fc.bulkItems["/system/resource"] = []MikrotikItem{{".id": "*1", "version": "7.22"}}
+
+	if _, err := ReadItems(nil, "/system/resource", fc); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, pathCached := fc.cache.Lookup("/system/resource", "*1"); pathCached {
+		t.Errorf("datasource-style read (id==nil) populated the cache — must bypass")
+	}
+}
+
+func TestReadItems_CacheEnabled_NameIdType_BypassesCache(t *testing.T) {
+	fc := newFakeClient(true)
+	fc.filtered["/interface/vlan|?name=vlan10"] = MikrotikItem{".id": "*7F", "name": "vlan10"}
+
+	res, err := ReadItems(&ItemId{Name, "vlan10"}, "/interface/vlan", fc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(*res) != 1 || (*res)[0]["name"] != "vlan10" {
+		t.Errorf("got %v, want vlan10", *res)
+	}
+	if got := fc.filteredReadCount("/interface/vlan"); got != 1 {
+		t.Errorf("filtered GET calls = %d, want 1", got)
+	}
+	if got := fc.bulkReadCount("/interface/vlan"); got != 0 {
+		t.Errorf("Name lookup triggered bulk read — must bypass cache")
+	}
+}
+
+func TestReadItems_CacheEnabled_BulkGetError_Propagates(t *testing.T) {
+	fc := newFakeClient(true)
+	fc.sendErr = errors.New("http 500")
+
+	_, err := ReadItems(&ItemId{Id, "*1"}, "/ip/dns/static", fc)
+	if err == nil || !strings.Contains(err.Error(), "http 500") {
+		t.Errorf("err = %v, want propagation of http 500", err)
+	}
+	if _, _, pathCached := fc.cache.Lookup("/ip/dns/static", "*1"); pathCached {
+		t.Errorf("cache was populated after failed bulk GET — must stay empty so next call retries")
+	}
+}
+
+func TestReadItems_CacheEnabled_ParallelCallsCoalesceToOneBulkGet(t *testing.T) {
+	fc := newFakeClient(true)
+	items := make([]MikrotikItem, 100)
+	for i := range items {
+		items[i] = MikrotikItem{".id": fmt.Sprintf("*%d", i), "seq": fmt.Sprintf("%d", i)}
+	}
+	fc.bulkItems["/ip/dns/static"] = items
+
+	// The fake's SendRequest is fast so singleflight may not coalesce every
+	// call — caching correctness is the real contract. We assert the weaker
+	// invariant that the number of bulk GETs is bounded far below the worker
+	// count, which is what the feature promises.
+	const workers = 100
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func(i int) {
+			defer wg.Done()
+			id := fmt.Sprintf("*%d", i)
+			res, err := ReadItems(&ItemId{Id, id}, "/ip/dns/static", fc)
+			if err != nil {
+				t.Errorf("worker %d: %v", i, err)
+				return
+			}
+			if len(*res) != 1 || (*res)[0]["seq"] != fmt.Sprintf("%d", i) {
+				t.Errorf("worker %d got %v", i, *res)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// With a fast in-memory fake, singleflight may not coalesce every single
+	// call — but the number of bulk GETs must be small and bounded (far less
+	// than one per worker). Caching correctness is the real contract.
+	got := fc.bulkReadCount("/ip/dns/static")
+	if got >= workers {
+		t.Errorf("bulk GET calls = %d, want far fewer than %d (cache must amortize)", got, workers)
+	}
+	if got := fc.filteredReadCount("/ip/dns/static"); got != 0 {
+		t.Errorf("filtered GET calls = %d, want 0 when cache enabled", got)
+	}
+}
+
+// ---------- CRUD invalidation tests ----------
+
+func TestCreateItem_Success_InvalidatesPath(t *testing.T) {
+	fc := newFakeClient(true)
+	fc.bulkItems["/ip/dns/static"] = []MikrotikItem{{".id": "*1"}}
+	// Prime the cache.
+	if _, err := ReadItems(&ItemId{Id, "*1"}, "/ip/dns/static", fc); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, pathCached := fc.cache.Lookup("/ip/dns/static", "*1"); !pathCached {
+		t.Fatal("cache not primed")
+	}
+
+	if _, err := CreateItem(context.Background(), MikrotikItem{"name": "new"}, "/ip/dns/static", fc); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, pathCached := fc.cache.Lookup("/ip/dns/static", "*1"); pathCached {
+		t.Errorf("cache was not invalidated after CreateItem")
+	}
+}
+
+// Guard against regression where DeleteItem's path mutation (appending "/" + id
+// for REST) would invalidate the wrong cache key. Also exercises the success
+// path of DeleteItem invalidation.
+func TestDeleteItem_RestTransport_InvalidatesBasePath(t *testing.T) {
+	fc := newFakeClient(true)
+	fc.bulkItems["/ip/dns/static"] = []MikrotikItem{{".id": "*1"}}
+	if _, err := ReadItems(&ItemId{Id, "*1"}, "/ip/dns/static", fc); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := DeleteItem(&ItemId{Id, "*1"}, "/ip/dns/static", fc); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, pathCached := fc.cache.Lookup("/ip/dns/static", "*1"); pathCached {
+		t.Errorf("cache for base path /ip/dns/static was not invalidated (DeleteItem suffixed the id)")
+	}
+	// Sanity: the wrong cache key shouldn't magically appear.
+	if _, _, pathCached := fc.cache.Lookup("/ip/dns/static/*1", ""); pathCached {
+		t.Errorf("cache entry appeared under the suffixed path — invalidation used the wrong key")
+	}
+}
+

--- a/routeros/provider.go
+++ b/routeros/provider.go
@@ -108,6 +108,19 @@ func Provider() *schema.Provider {
 				Description:  "HTTP Client Timeout",
 				ValidateFunc: validation.IntAtLeast(5),
 			},
+			"bulk_read_refresh": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				DefaultFunc: schema.MultiEnvDefaultFunc(
+					[]string{"ROS_BULK_READ_REFRESH"},
+					false,
+				),
+				Description: "When true, Terraform state refresh fetches each resource path in a single bulk " +
+					"GET and serves subsequent per-id reads from an in-memory cache invalidated on writes. " +
+					"Speeds up plans over large resource sets (e.g. thousands of DNS records) by an order " +
+					"of magnitude. Opt-in; default false preserves the traditional per-id filtered GET " +
+					"behavior (env: ROS_BULK_READ_REFRESH).",
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 

--- a/routeros/provider.go
+++ b/routeros/provider.go
@@ -118,8 +118,10 @@ func Provider() *schema.Provider {
 				Description: "When true, Terraform state refresh fetches each resource path in a single bulk " +
 					"GET and serves subsequent per-id reads from an in-memory cache invalidated on writes. " +
 					"Speeds up plans over large resource sets (e.g. thousands of DNS records) by an order " +
-					"of magnitude. Opt-in; default false preserves the traditional per-id filtered GET " +
-					"behavior (env: ROS_BULK_READ_REFRESH).",
+					"of magnitude when most records on a path are managed by Terraform. Can slow down plans " +
+					"on configs that manage only a handful of records on a path populated by many unmanaged " +
+					"entries, because each bulk fetch returns the full path. Opt-in; default false preserves " +
+					"the traditional per-id filtered GET behavior (env: ROS_BULK_READ_REFRESH).",
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{

--- a/routeros/resource_ip_dns_record_bulk_read_test.go
+++ b/routeros/resource_ip_dns_record_bulk_read_test.go
@@ -2,8 +2,6 @@ package routeros
 
 import (
 	"fmt"
-	"io"
-	"net/http"
 	"strings"
 	"testing"
 
@@ -69,13 +67,9 @@ func TestAccDnsRecord_BulkReadRefresh_Roundtrip(t *testing.T) {
 
 func TestAccDnsRecord_BulkReadRefresh_DetectsExternalDelete(t *testing.T) {
 	// Confirms the cache does not mask out-of-band deletions. The test
-	// deletes a record directly via the REST API between steps and asserts
-	// that the next plan surfaces the drift so Terraform recreates it.
+	// deletes a record directly via the active transport between steps and
+	// asserts that the next plan surfaces the drift so Terraform recreates it.
 	for _, name := range testNames {
-		if !strings.Contains(name, "REST") {
-			// The out-of-band delete helper uses the REST API.
-			continue
-		}
 		t.Run(name, func(t *testing.T) {
 			resource.Test(t, resource.TestCase{
 				PreCheck: func() {
@@ -103,8 +97,11 @@ func TestAccDnsRecord_BulkReadRefresh_DetectsExternalDelete(t *testing.T) {
 	}
 }
 
-// deleteDnsRecordOutOfBand issues a DELETE directly against the REST API,
-// bypassing Terraform. Used to simulate external drift.
+// deleteDnsRecordOutOfBand deletes the backing RouterOS record through the
+// provider's active transport (REST or native API) without going through the
+// DeleteItem CRUD helper that would invalidate the bulk cache. The direct
+// SendRequest call mirrors how a sibling Terraform config or admin would
+// mutate the router externally.
 func deleteDnsRecordOutOfBand(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -115,26 +112,17 @@ func deleteDnsRecordOutOfBand(resourceName string) resource.TestCheckFunc {
 		if id == "" {
 			return fmt.Errorf("%s: empty id", resourceName)
 		}
-		client, ok := testAccProvider.Meta().(*RestClient)
+		client, ok := testAccProvider.Meta().(Client)
 		if !ok {
-			return fmt.Errorf("out-of-band delete only supports REST transport")
+			return fmt.Errorf("provider meta is not a routeros.Client: %T", testAccProvider.Meta())
 		}
-		url := fmt.Sprintf("%s/rest/ip/dns/static/%s", client.HostURL, id)
-		req, err := http.NewRequest(http.MethodDelete, url, nil)
-		if err != nil {
-			return err
+		url := &URL{Path: "/ip/dns/static"}
+		if client.GetTransport() == TransportREST {
+			url.Path += "/" + id
+		} else {
+			url.Query = []string{"=.id=" + id}
 		}
-		req.SetBasicAuth(client.Username, client.Password)
-		res, err := client.Do(req)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = res.Body.Close() }()
-		body, _ := io.ReadAll(res.Body)
-		if res.StatusCode >= 400 {
-			return fmt.Errorf("out-of-band DELETE %s: status=%d body=%s", url, res.StatusCode, body)
-		}
-		return nil
+		return client.SendRequest(crudDelete, url, nil, &MikrotikItem{})
 	}
 }
 

--- a/routeros/resource_ip_dns_record_bulk_read_test.go
+++ b/routeros/resource_ip_dns_record_bulk_read_test.go
@@ -21,7 +21,7 @@ provider "routeros" {
 func testAccBulkReadDnsRecordsConfig(providerBlock string, count int) string {
 	var b strings.Builder
 	b.WriteString(providerBlock)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		fmt.Fprintf(&b, `
 resource "routeros_dns_record" "bulk_%d" {
 	address = "127.0.0.1"

--- a/routeros/resource_ip_dns_record_bulk_read_test.go
+++ b/routeros/resource_ip_dns_record_bulk_read_test.go
@@ -1,0 +1,140 @@
+package routeros
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// providerConfigBulkRead enables the opt-in bulk_read_refresh flag so the
+// provider under test exercises the cache path on every Read.
+const providerConfigBulkRead = `
+provider "routeros" {
+	insecure          = true
+	bulk_read_refresh = true
+}
+`
+
+func testAccBulkReadDnsRecordsConfig(providerBlock string, count int) string {
+	var b strings.Builder
+	b.WriteString(providerBlock)
+	for i := 0; i < count; i++ {
+		fmt.Fprintf(&b, `
+resource "routeros_dns_record" "bulk_%d" {
+	address = "127.0.0.1"
+	name    = "bulk-test-%d.example"
+	type    = "A"
+	ttl     = "1m"
+}
+`, i, i)
+	}
+	return b.String()
+}
+
+func TestAccDnsRecord_BulkReadRefresh_Roundtrip(t *testing.T) {
+	for _, name := range testNames {
+		t.Run(name, func(t *testing.T) {
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(t)
+					testSetTransportEnv(t, name)
+				},
+				ProviderFactories: testAccProviderFactories,
+				CheckDestroy:      testCheckResourceDestroy("/ip/dns/static", "routeros_dns_record"),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccBulkReadDnsRecordsConfig(providerConfigBulkRead, 5),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestCheckResourceAttr("routeros_dns_record.bulk_0", "name", "bulk-test-0.example"),
+							resource.TestCheckResourceAttr("routeros_dns_record.bulk_4", "name", "bulk-test-4.example"),
+						),
+					},
+					// Second step with identical config: the refresh goes through the cache.
+					// Any drift reported by Terraform here would be a correctness regression.
+					{
+						Config:             testAccBulkReadDnsRecordsConfig(providerConfigBulkRead, 5),
+						PlanOnly:           true,
+						ExpectNonEmptyPlan: false,
+					},
+				},
+			})
+		})
+	}
+}
+
+func TestAccDnsRecord_BulkReadRefresh_DetectsExternalDelete(t *testing.T) {
+	// Confirms the cache does not mask out-of-band deletions. The test
+	// deletes a record directly via the REST API between steps and asserts
+	// that the next plan surfaces the drift so Terraform recreates it.
+	for _, name := range testNames {
+		if !strings.Contains(name, "REST") {
+			// The out-of-band delete helper uses the REST API.
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(t)
+					testSetTransportEnv(t, name)
+				},
+				ProviderFactories: testAccProviderFactories,
+				CheckDestroy:      testCheckResourceDestroy("/ip/dns/static", "routeros_dns_record"),
+				Steps: []resource.TestStep{
+					{
+						Config: testAccBulkReadDnsRecordsConfig(providerConfigBulkRead, 3),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestCheckResourceAttr("routeros_dns_record.bulk_1", "name", "bulk-test-1.example"),
+							deleteDnsRecordOutOfBand("routeros_dns_record.bulk_1"),
+						),
+					},
+					{
+						Config:             testAccBulkReadDnsRecordsConfig(providerConfigBulkRead, 3),
+						PlanOnly:           true,
+						ExpectNonEmptyPlan: true, // the out-of-band delete must produce a plan
+					},
+				},
+			})
+		})
+	}
+}
+
+// deleteDnsRecordOutOfBand issues a DELETE directly against the REST API,
+// bypassing Terraform. Used to simulate external drift.
+func deleteDnsRecordOutOfBand(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("%s: resource not found in state", resourceName)
+		}
+		id := rs.Primary.ID
+		if id == "" {
+			return fmt.Errorf("%s: empty id", resourceName)
+		}
+		client, ok := testAccProvider.Meta().(*RestClient)
+		if !ok {
+			return fmt.Errorf("out-of-band delete only supports REST transport")
+		}
+		url := fmt.Sprintf("%s/rest/ip/dns/static/%s", client.HostURL, id)
+		req, err := http.NewRequest(http.MethodDelete, url, nil)
+		if err != nil {
+			return err
+		}
+		req.SetBasicAuth(client.Username, client.Password)
+		res, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = res.Body.Close() }()
+		body, _ := io.ReadAll(res.Body)
+		if res.StatusCode >= 400 {
+			return fmt.Errorf("out-of-band DELETE %s: status=%d body=%s", url, res.StatusCode, body)
+		}
+		return nil
+	}
+}
+


### PR DESCRIPTION
Fixes #976.

## Summary

State refresh on paths with many resources currently takes time proportional to the resource count because the provider issues one filtered `GET` per resource, and RouterOS's www service processes these serially. See #976 for the full problem analysis, measurements, and prior art.

This PR adds an opt-in provider attribute `bulk_read_refresh` (default `false`, env `ROS_BULK_READ_REFRESH`). When enabled, the first `ReadItems` call on a path triggers one bulk `GET <path>` and caches the response indexed by `.id`. Subsequent per-id reads on the same path serve from memory. Successful `Create`/`Update`/`Delete` on a path invalidates its cache entry.

## Measured impact

Against a live MikroTik hEX with 1868 `routeros_dns_record` entries on `/ip/dns/static`:

| Config | Wall |
|---|---|
| v1.99.1 unmodified | 3m 42s |
| `bulk_read_refresh=true` | 5.7s (~46× faster) |

A second plan reports no changes — refresh produces identical state.

## Design

- Cache keyed by path, indexed by `.id`. Scoped to one provider instance (one terraform command).
- First miss populates via bulk GET; concurrent misses on the same path coalesced by `golang.org/x/sync/singleflight` (already transitive via `terraform-plugin-sdk`).
- Successful `Create`/`Update`/`Delete` invalidate that path's entry. Failed writes do not invalidate (router state is unchanged, so the cache is still correct).
- **Datasource reads** (`id == nil`) and **Name-type lookups** (`IdType == Name`) bypass the cache — their semantics differ from the per-id reads the cache is built for.
- **Transport-neutral**: benefits both REST (`http[s]://`) and native API (`api[s]://`). The fix sits in the shared `ReadItems`/`CreateItem`/`UpdateItem`/`DeleteItem` helpers in `routeros/mikrotik_crud.go`, so every resource using `DefaultRead` inherits it (~150 resources).

## Test plan

- [x] 6 unit tests for `BulkReadCache`: Lookup (hit / negative-hit-on-known-path / empty-cache), Invalidate, singleflight coalescing (50 concurrent callers → 1 bulk fetch), error propagation
- [x] 11 unit tests for `ReadItems`/`CreateItem`/`DeleteItem` using a fake `Client`: cache-disabled → filtered GET, first-call → bulk GET, second-call → 0 requests, id-not-in-bulk → empty, post-invalidate refetch, nil-id bypass, Name-type bypass, bulk-GET error propagation, 100-goroutine coalescing, Create-success invalidation, Delete path-mutation regression guard
- [x] 2 acceptance tests (run with `TF_ACC=1` + `ROS_*` envs) across both REST and API transports: roundtrip (apply + plan-only, expect no drift) and out-of-band drift detection (external DELETE → plan detects drift)
- [x] All 17 unit tests pass 3× under `go test -count=3`
- [x] Verified against real router (1868 records): 3m 42s → 5.7s

## Questions for reviewers

1. Opt-in default, or on-by-default with opt-out? I chose opt-in to preserve existing behavior during rollout.
2. Any resources with `IdType==Name` Read semantics that the cache bypass might still subtly affect? I audited the codebase and found only `ResourceCreate` post-create name-search and `ResourceCreateAndWait` polling — both bypass the cache explicitly.