### PR TITLE
fix(interface_bridge_port): Add missing `actual_path_cost` attribute

### DIFF
--- a/routeros/resource_interface_bridge_port.go
+++ b/routeros/resource_interface_bridge_port.go
@@ -15,6 +15,7 @@ import (
   {
     ".id": "*0",
     ".nextid": "*1",
+    "actual-path-cost": "10",
     "auto-isolate": "false",
     "bpdu-guard": "false",
     "bridge": "bridge",
@@ -91,6 +92,11 @@ func ResourceInterfaceBridgePort() *schema.Resource {
 		"nextid": {
 			Type:     schema.TypeString,
 			Computed: true,
+		},
+		"actual_path_cost": {
+			Type:        schema.TypeInt,
+			Computed:    true,
+			Description: "Shows the actual port path-cost. Either manually applied or automatically determined based on the interface speed and the port-cost-mode setting.",
 		},
 		"auto_isolate": {
 			Type:     schema.TypeBool,


### PR DESCRIPTION
Fixes #961

This was the only issue I stumbled upon so far after updating to ROS 7.21 (LTS)

Description taken directly from: https://help.mikrotik.com/docs/spaces/ROS/pages/328068/Bridging+and+Switching