### PR TITLE
fix(ip_address): make vrf read-only to fix update errors on RouterOS 7.21+

### DIFF
--- a/routeros/provider_schema_helpers.go
+++ b/routeros/provider_schema_helpers.go
@@ -488,6 +488,11 @@ var (
 		Description:      "The VRF table this resource operates on.",
 		DiffSuppressFunc: AlwaysPresentNotUserProvided,
 	}
+	PropVrfRo = &schema.Schema{
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "The VRF table this resource operates on.",
+	}
 )
 
 // PropMtuRw MTU value can be integer or 'auto'.

--- a/routeros/resource_ip_address.go
+++ b/routeros/resource_ip_address.go
@@ -54,7 +54,13 @@ func ResourceIPAddress() *schema.Resource {
 			Computed:    true,
 			Description: "Whether address belongs to an interface which is a slave port to some other master interface",
 		},
-		KeyVrf: PropVrfRw,
+		// vrf is read-only here: RouterOS 7.21+ rejects writes to it on
+		// /ip address rows tied to interfaces that don't carry a VRF
+		// concept (notably WireGuard interfaces, where SET-with-vrf=main
+		// errors with "unknown parameter vrf"). Surfacing it as Computed
+		// keeps the field readable in state without sending it back on
+		// updates. Closes #944.
+		KeyVrf: PropVrfRo,
 	}
 	return &schema.Resource{
 		CreateContext: DefaultCreate(resSchema),


### PR DESCRIPTION
Closes #944.

## Summary

RouterOS 7.21+ rejects writes to the `vrf` field on `/ip/address` rows tied to interfaces that don't carry a VRF concept (notably WireGuard interfaces). Any update to such a row — including benign ones like adding a `comment` — fails with:

```
Error: from RouterOS device: unknown parameter vrf
  with routeros_ip_address.X,
  on config.tf.json line N, in resource.routeros_ip_address.X:
```

The previous schema marked vrf as \`Optional\` with the \`AlwaysPresentNotUserProvided\` diff-suppress. That suppresses the diff in plan output but does **not** stop the value from being serialised back to RouterOS on update — \`isEmpty\` in \`mikrotik_serialize.go\` returns false because the value read from state (\`\"main\"\`) is non-empty, so vrf goes into every SET request.

## Approach

Switch vrf to a Computed-only \`PropVrfRo\`. The field stays readable in state for inspection (and surfaces correctly in datasources), but the serialiser never emits it on update. If a future RouterOS release reinstates writeability we can swap back to \`PropVrfRw\` without churn.

This is the same one-line fix already in #910 — extracted into its own minimal PR since #910 contains many unrelated changes for container mounts and other 7.21 attribute drift, and is large enough that it'll likely take longer to review/merge.

## Test plan

- [x] Verified on a live RouterOS 7.21.3 router (hAP ac²) that \`tofu apply\` against \`routeros_ip_address.wg_backbone\` (a /32 on a WireGuard interface) now succeeds where it previously failed with \"unknown parameter vrf\".
- [x] \`go build ./routeros/...\` clean.
- [x] \`go vet ./routeros/...\` clean (one pre-existing unrelated warning in resource_interface_wireless_test.go).
- [ ] Acceptance tests not run locally (need a CI RouterOS instance).