### PR TITLE
fix(dhcp): preserve required server fields when unset in user config

### DIFF
--- a/routeros/resource_ip_dhcp_server.go
+++ b/routeros/resource_ip_dhcp_server.go
@@ -91,7 +91,11 @@ func ResourceDhcpServer() *schema.Resource {
 		"dynamic_lease_identifiers": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "Dynamic lease identifier",
+			Computed:    true,
+			Description: "Dynamic lease identifier. RouterOS requires at least one identifier on modify, " +
+				"so this field is preserved (DiffSuppressed) when not set in user config — clearing it " +
+				"would cause apply to error with \"at least one dynamic lease identifier should be specified\".",
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"support_broadband_tr101": {
 			Type:        schema.TypeBool,

--- a/routeros/resource_ipv6_dhcp_server.go
+++ b/routeros/resource_ipv6_dhcp_server.go
@@ -120,8 +120,10 @@ func ResourceIpv6DhcpServer() *schema.Resource {
 		"prefix_pool": {
 			Type:             schema.TypeString,
 			Optional:         true,
+			Computed:         true,
 			Description:      "IPv6 pool, from which to take IPv6 prefix for the clients.",
 			AtLeastOneOf:     []string{"address_pool", "prefix_pool"},
+			DiffSuppressFunc: AlwaysPresentNotUserProvided,
 		},
 		"rapid_commit": {
 			Type:             schema.TypeBool,


### PR DESCRIPTION
## Summary

Two related bugs that surface when applying terraform changes against existing \`/ip/dhcp-server\` and \`/ipv6/dhcp-server\` rows that have config the user hasn't reproduced in their .tf:

1. **\`routeros_ip_dhcp_server.dynamic_lease_identifiers\`** — RouterOS requires at least one identifier (\`\"client-mac,client-id\"\` is the factory default). When the user's tf omits the field, the previous schema (\`Optional\`, no diff-suppress) emits an empty value on modify, which RouterOS rejects:
   \`\`\`
   Error: from RouterOS device: failure: at least one dynamic lease identifier should be specified
   \`\`\`

2. **\`routeros_ipv6_dhcp_server.prefix_pool\`** — when the live router has \`prefix_pool=\"static-only\"\` (or any other value) and the user only declares \`address_pool\`, the previous schema would clear \`prefix_pool\` on modify, which can break running prefix delegation.

## Approach

Both fields gain \`Computed: true\` and the \`AlwaysPresentNotUserProvided\` \`DiffSuppress\`, mirroring the pattern used for other \"preserve when unset\" RouterOS fields elsewhere in the provider (e.g. \`vrf\`, \`max_sessions\` on \`routeros_ip_service\`).

## Test plan

- [x] Verified on a live RouterOS 7.21.3 router that:
  - \`tofu apply\` no longer fails with the \"dynamic lease identifier\" error when \`dynamic_lease_identifiers\` is omitted from the resource
  - \`prefix_pool=\"static-only\"\` is preserved across applies that don't declare it
- [x] \`go build ./routeros/...\` clean.