### PR TITLE
fix: respect HTTP_PROXY + HTTPS_PROXY env vars in REST client

### DIFF
--- a/routeros/mikrotik_client.go
+++ b/routeros/mikrotik_client.go
@@ -175,6 +175,8 @@ func NewClient(ctx context.Context, d *schema.ResourceData) (interface{}, diag.D
 		Timeout: time.Duration(d.Get("rest_timeout").(int)) * time.Second,
 		Transport: &http.Transport{
 			TLSClientConfig: &tlsConf,
+			// http.DefaultTransport sets this, allows us to use proxies as set in env vars.
+			Proxy: http.ProxyFromEnvironment,
 		},
 	}
 


### PR DESCRIPTION
I'm accessing my RouterOS API via a Tailscale SOCK5 proxy. [Go respects these env vars by default](https://pkg.go.dev/net/http#DefaultTransport), but since we create a custom transport (to set the `tls.Config`), we lose that default.

Before this PR, I wasn't able to run `terraform {plan,apply,etc}` even with the env vars set, and I've confirmed it works as expected with this PR applied.