### PR TITLE
user_manager_user: handle "unlimited" in shared_users

### DIFF
--- a/routeros/resource_user_manager_user.go
+++ b/routeros/resource_user_manager_user.go
@@ -56,7 +56,7 @@ func ResourceUserManagerUser() *schema.Resource {
 			Description: "The password of the user for session authentication.",
 		},
 		"shared_users": {
-			Type:        schema.TypeInt,
+			Type:        schema.TypeString, // Maybe "unlimited"
 			Optional:    true,
 			Default:     1,
 			Description: "The total amount of sessions the user can simultaneously establish.",


### PR DESCRIPTION
This is the same as #803 / #805, but for `routeros_user_manager_user`. Tested against RouterOS 7.13.

Without this patch terraform errors out while trying to import an existing resource:
```
  ╷
  │ Error: strconv.Atoi: parsing "unlimited": invalid syntax for 'shared_users' field
  │ 
  │ 
  ╵
```