### PR TITLE
fix: make ip_service, ip_dns and ip_neighbor_discovery_settings importable

### DIFF
--- a/docs/resources/ip_dns.md
+++ b/docs/resources/ip_dns.md
@@ -48,6 +48,6 @@ resource "routeros_ip_dns" "dns-server" {
 ## Import
 Import is supported using the following syntax:
 ```shell
-#The DNS Settings can not be imported. 
-#Terraform will ignore the current settings and will overwrite the current settings with the settings defined in Terraform.
+# The DNS settings are a singleton; import with '.'.
+terraform import routeros_ip_dns.test .
 ```

--- a/examples/resources/routeros_ip_dns/import.sh
+++ b/examples/resources/routeros_ip_dns/import.sh
@@ -1,2 +1,2 @@
-#The DNS Settings can not be imported. 
-#Terraform will ignore the current settings and will overwrite the current settings with the settings defined in Terraform.
+# The DNS settings are a singleton; import with '.'.
+terraform import routeros_ip_dns.test .

--- a/routeros/resource_ip_dns.go
+++ b/routeros/resource_ip_dns.go
@@ -196,6 +196,14 @@ func ResourceDns() *schema.Resource {
 			return nil
 		},
 
+		// Settings singleton (DefaultSystemRead): the /ip/dns object has no ".id"/"name"
+		// to resolve, so import via passthrough like the other *_settings singletons
+		// (ip_settings, system_identity). The read ignores the import ID and rebuilds it
+		// from the resource path.
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
 		Schema:        resSchema,
 		SchemaVersion: 1,
 		StateUpgraders: []schema.StateUpgrader{

--- a/routeros/resource_ip_dns_test.go
+++ b/routeros/resource_ip_dns_test.go
@@ -28,6 +28,15 @@ func TestAccResourceDnsTest_basic(t *testing.T) {
 					{
 						Config: testAccResourceDnsConfig(),
 					},
+					{
+						// Settings singleton: previously had no Importer at all.
+						// Verifies import now succeeds via passthrough (the read
+						// rebuilds the ID from the resource path).
+						ResourceName:      testResourceDnsTask,
+						ImportState:       true,
+						ImportStateId:     ".",
+						ImportStateVerify: false,
+					},
 				},
 			})
 

--- a/routeros/resource_ip_neighbor_discovery.go
+++ b/routeros/resource_ip_neighbor_discovery.go
@@ -112,8 +112,12 @@ func ResourceIpNeighborDiscoverySettings() *schema.Resource {
 		UpdateContext: DefaultSystemUpdate(resSchema),
 		DeleteContext: DefaultSystemDelete(resSchema),
 
+		// Settings singleton (DefaultSystemRead): there is no ".id"/"name" field to
+		// resolve, so use passthrough like the other *_settings singletons (ip_settings,
+		// system_identity). ImportStateCustomContext requires a ".id" in the response and
+		// fails on this object. Read ignores the import ID and rebuilds it from the path.
 		Importer: &schema.ResourceImporter{
-			StateContext: ImportStateCustomContext(resSchema),
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: resSchema,

--- a/routeros/resource_ip_neighbor_discovery_test.go
+++ b/routeros/resource_ip_neighbor_discovery_test.go
@@ -32,6 +32,15 @@ func TestAccIpNeighborDiscoverySettingsTest_basic(t *testing.T) {
 							resource.TestCheckResourceAttr(testIpNeighborDiscoverySettings, "discover_interface_list", "none"),
 						),
 					},
+					{
+						// Settings singleton: previously wired to ImportStateCustomContext,
+						// which requires a ".id" the object doesn't have. Verifies import now
+						// succeeds via passthrough (the read rebuilds the ID from the path).
+						ResourceName:      testIpNeighborDiscoverySettings,
+						ImportState:       true,
+						ImportStateId:     ".",
+						ImportStateVerify: false,
+					},
 				},
 			})
 		})

--- a/routeros/resource_ip_service.go
+++ b/routeros/resource_ip_service.go
@@ -2,6 +2,7 @@ package routeros
 
 import (
 	"context"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -125,8 +126,31 @@ func ResourceIpService() *schema.Resource {
 		UpdateContext: resCreateUpdate,
 		DeleteContext: DefaultSystemDelete(resSchema),
 
+		// ip_service is a fixed, name-addressed menu (IdType=Name): Create/Update/Read all
+		// key on the service name, and the API returns "name" — never the schema's Required
+		// "numbers" selector. Import by the service name (as the docs show:
+		// `terraform import '...["www-ssl"]' www-ssl`) and seed "numbers" from it so the
+		// post-import read is drift-free. Plain passthrough would leave "numbers" empty
+		// (the read never sets it), and the generic ImportStateCustomContext would instead
+		// store the internal ".id" (e.g. *6), which the name-keyed read can't find.
 		Importer: &schema.ResourceImporter{
-			StateContext: ImportStateCustomContext(resSchema),
+			StateContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+				// Import by service name, e.g. `www-ssl`. The provider-wide
+				// `field=value` form is also accepted for the name/numbers fields
+				// (e.g. `name=www-ssl`).
+				id := d.Id()
+				if k, v, found := strings.Cut(id, "="); found && (k == "name" || k == "numbers") {
+					id = v
+					d.SetId(id)
+				}
+				// Seed the Required "numbers" selector from the ID: the API returns
+				// "name" but never "numbers", so without this the imported resource
+				// would show a permanent diff on "numbers".
+				if err := d.Set("numbers", id); err != nil {
+					return nil, err
+				}
+				return []*schema.ResourceData{d}, nil
+			},
 		},
 
 		Schema: resSchema,

--- a/routeros/resource_ip_service_test.go
+++ b/routeros/resource_ip_service_test.go
@@ -25,6 +25,16 @@ func TestAccIpServiceTest_basic(t *testing.T) {
 							resource.TestCheckResourceAttr(testIpServiceAddress, "name", "telnet"),
 						),
 					},
+					{
+						// Import by service name (IdType=Name). Verifies the state
+						// round-trips with no drift — in particular that the Required
+						// "numbers" selector is seeded from the import ID (the API only
+						// returns "name", never "numbers").
+						ResourceName:      testIpServiceAddress,
+						ImportState:       true,
+						ImportStateId:     "telnet",
+						ImportStateVerify: true,
+					},
 				},
 			})
 		})


### PR DESCRIPTION
## What

Three resources couldn't be imported cleanly. This fixes all three and adds an import test for each.

### `routeros_ip_service`
`IdType` is `Name` (the menu is fixed and name-addressed), but the resource used the generic importer, which stored the internal `.id` (e.g. `*6`). The name-keyed read then couldn't find it, and the `Required` `numbers` selector was never populated — a permanent post-import diff. A small custom importer now imports by service name (e.g. `www-ssl`), also accepts the provider-wide `name=`/`numbers=` form, and seeds `numbers` from the id so the first read is drift-free.

### `routeros_ip_dns`
The DNS settings are a singleton but had no importer, so they couldn't be imported at all. Added `ImportStatePassthroughContext` (import with `.`). The example `import.sh` and generated doc are corrected from "can not be imported" accordingly.

### `routeros_ip_neighbor_discovery_settings`
Also a singleton, but it used `ImportStateCustomContext` (which expects a `field=value` id) and failed to import. Switched to `ImportStatePassthroughContext`.

## Tests
Each resource gains an import step — `ImportStateVerify` for `ip_service`, `ImportState` for the two singletons.

---
_Disclosure: an AI assistant (Claude) helped draft this change; a human reviewed it and verified all three imports against real RouterOS hardware before submission._
