### PR TITLE
fix(system_script): add romon and dude to policy validator

### DIFF
--- a/routeros/resource_system_script.go
+++ b/routeros/resource_system_script.go
@@ -54,7 +54,7 @@ func ResourceSystemScript() *schema.Resource {
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 				ValidateFunc: validation.StringInSlice([]string{"ftp", "reboot", "read", "write", "policy", "test",
-					"password", "sniff", "sensitive"}, false),
+					"password", "sniff", "sensitive", "romon", "dude"}, false),
 			},
 			Description: `List of applicable policies:
 	* ftp - Policy that grants full rights to log in remotely via FTP, to read/write/erase files and to transfer files from/to the router. Should be used together with read/write policies.  


### PR DESCRIPTION
## Summary

- Add `romon` and `dude` to the `policy` field's `StringInSlice` validator on `routeros_system_script`
- This aligns with `routeros_system_scheduler`, which already allows these values

## Problem

RouterOS 7.23+ includes `romon` in the default policy set for scripts. When the provider reads (refreshes) a script resource, the schema validation rejects `romon`:

```
expected policy.5 to be one of ["ftp" "reboot" "read" "write" "policy" "test" "password" "sniff" "sensitive"], got romon
```

## Fix

One-line change to match the scheduler resource's validator, which already includes `romon` and `dude`.